### PR TITLE
TileDB integration

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ install_requires = [
     'numba',
     'pandas>=0.25',
     'param',
-    'pyarrow>=0.15',
+    'pyarrow>=1.0',
     'python-snappy',
     'retrying',
 ]

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ install_requires = [
     'pyarrow>=1.0',
     'python-snappy',
     'retrying',
+    'tiledb>=0.8.6',
 ]
 
 # Checking for platform explicitly because

--- a/spatialpandas/geometry/flattened.py
+++ b/spatialpandas/geometry/flattened.py
@@ -1,0 +1,170 @@
+import re
+
+import numpy as np
+from pandas.api.extensions import (
+    ExtensionArray,
+    ExtensionDtype,
+    no_default,
+    register_extension_dtype,
+)
+from pandas.api.types import is_dtype_equal
+from pandas.core.dtypes.base import registry
+
+from ..geometry import GeometryArray, GeometryDtype
+from ..geometry.basefixed import GeometryFixed, GeometryFixedArray
+from ..geometry.baselist import GeometryList, GeometryListArray
+
+
+@register_extension_dtype
+class FlatGeometryDtype(ExtensionDtype):
+    _metadata = ("geometry_dtype",)
+
+    type = np.ndarray
+    na_value = None
+
+    def __init__(self, geometry_dtype):
+        self.geometry_dtype = geometry_dtype
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}({self.geometry_dtype})"
+
+    @property
+    def name(self):
+        return f"flat[{self.geometry_dtype}]"
+
+    @property
+    def subtype(self):
+        return self.geometry_dtype.subtype
+
+    @classmethod
+    def construct_array_type(cls):
+        return FlatGeometryArray
+
+    @classmethod
+    def construct_from_string(cls, string):
+        msg = f"Cannot construct a '{cls.__name__}' from '{string}'"
+
+        match = re.match(fr"^flat\[(.+)\]$", string)
+        if match is None:
+            raise TypeError(msg)
+
+        wrapped_dtype = registry.find(match.group(1))
+        if wrapped_dtype is None:
+            raise TypeError(msg)
+
+        try:
+            return cls(wrapped_dtype)
+        except Exception:
+            raise TypeError(msg)
+
+
+class FlatGeometryArray(ExtensionArray):
+    def __init__(self, geometry_array: GeometryArray):
+        self._geometry_array = geometry_array
+        self._dtype = FlatGeometryDtype(geometry_array.dtype)
+
+    @property
+    def dtype(self):
+        return self._dtype
+
+    def __len__(self):
+        return len(self._geometry_array)
+
+    def copy(self):
+        return self.__class__(self._geometry_array)
+
+    def isna(self):
+        return self._geometry_array.isna()
+
+    def to_numpy(self, dtype=None, copy=False, na_value=no_default):
+        result = flatten_geometry_array(self._geometry_array, dtype)
+        if na_value is not no_default:
+            result[self.isna()] = na_value
+        return result
+
+    def astype(self, dtype, copy=True):
+        if is_dtype_equal(dtype, self._dtype.geometry_dtype):
+            return self._geometry_array
+        return super().astype(dtype=dtype, copy=copy)
+
+    @classmethod
+    def _from_sequence(cls, scalars, *, dtype=None, copy=False):
+        if isinstance(scalars, cls):
+            return scalars
+
+        if isinstance(dtype, FlatGeometryDtype):
+            dtype = dtype.geometry_dtype
+
+        if isinstance(scalars, GeometryArray):
+            geometry_array = scalars.astype(dtype, copy=False)
+        elif isinstance(dtype, GeometryDtype):
+            geometry_array = unflatten_geometry_array(scalars, dtype)
+        else:
+            raise TypeError(f"[Flat]GeometryDtype expected, {dtype} passed")
+
+        return cls(geometry_array)
+
+
+def flatten_geometry_array(geometry_array: GeometryArray, dtype=None) -> np.ndarray:
+    if dtype is None:
+        dtype = geometry_array.numpy_dtype
+
+    if isinstance(geometry_array, GeometryFixedArray):
+        flatten = _flatten_fixed_geometry
+    elif isinstance(geometry_array, GeometryListArray):
+        flatten = _flatten_list_geometry
+    else:
+        raise TypeError(f"Flattening '{geometry_array.__class__}' not supported")
+
+    flat_arrays = np.empty(len(geometry_array), dtype="O")
+    for i, geometry in enumerate(geometry_array):
+        if geometry is not None:
+            flat_arrays[i] = flatten(geometry).astype(dtype, copy=False)
+    return flat_arrays
+
+
+def _flatten_fixed_geometry(geometry: GeometryFixed) -> np.ndarray:
+    return geometry.flat_values
+
+
+def _flatten_list_geometry(geometry: GeometryList) -> np.ndarray:
+    # For GeometryList subclasses with 0 nesting levels (MultiPoint, Line, Ring),
+    # `.buffer_offsets` returns a length-1 tuple of offsets that include
+    # all the flat values. These offsets are both unnecessary and mess up the
+    # unflattening by creating an extra nesting level, so ignore them
+    offsets = geometry.buffer_offsets if geometry._nesting_levels > 0 else ()
+    parts = [(len(offsets), *map(len, offsets))]
+    parts.extend(offsets)
+    parts.append(geometry.buffer_values)
+    return np.concatenate(parts)
+
+
+def unflatten_geometry_array(
+    ragged_array: np.ndarray, dtype: GeometryDtype
+) -> GeometryArray:
+    array_type = dtype.construct_array_type()
+
+    if issubclass(array_type, GeometryFixedArray):
+        return array_type(ragged_array)
+
+    if issubclass(array_type, GeometryListArray):
+        sub_arrays_list = []
+        for flat_array in ragged_array:
+            assert isinstance(flat_array, np.ndarray) and flat_array.ndim == 1
+            offsets_list = []
+            num_offsets = int(flat_array[0])
+            flat_offset = 1 + num_offsets
+            for offsets_length in flat_array[1:flat_offset]:
+                next_flat_offset = flat_offset + int(offsets_length)
+                offsets = flat_array[flat_offset:next_flat_offset].astype(np.int32)
+                offsets_list.append(offsets)
+                flat_offset = next_flat_offset
+
+            sub_arrays = flat_array[flat_offset:]
+            for offsets in reversed(offsets_list):
+                sub_arrays = [sub_arrays[i:j] for i, j in zip(offsets, offsets[1:])]
+            sub_arrays_list.append(sub_arrays)
+
+        return array_type(sub_arrays_list)
+
+    raise TypeError(f"Unflattening '{array_type}' not supported")

--- a/spatialpandas/io/__init__.py
+++ b/spatialpandas/io/__init__.py
@@ -1,3 +1,6 @@
 from .parquet import (  # noqa
     read_parquet, read_parquet_dask, to_parquet, to_parquet_dask
 )
+from .tiledb import (  # noqa
+    read_tiledb, to_tiledb
+)

--- a/spatialpandas/io/tiledb.py
+++ b/spatialpandas/io/tiledb.py
@@ -1,0 +1,38 @@
+from typing import Optional, Sequence
+
+import tiledb
+
+from ..geodataframe import GeoDataFrame
+from ..geometry import GeometryDtype
+from ..geometry.flattened import FlatGeometryArray, FlatGeometryDtype
+
+
+def to_tiledb(df: GeoDataFrame, uri: str, **kwargs) -> None:
+    new_columns = {}
+    varlen_types = set(kwargs.pop("varlen_types", ()))
+    for name, column in df.iteritems():
+        if isinstance(column.dtype, GeometryDtype):
+            new_column = FlatGeometryArray(column.values)
+            new_columns[name] = new_column
+            varlen_types.add(new_column.dtype)
+
+    if new_columns:
+        df = df.assign(**new_columns)
+
+    return tiledb.from_pandas(uri, df, varlen_types=varlen_types, **kwargs)
+
+
+def read_tiledb(
+    uri: str,
+    columns: Optional[Sequence[str]] = None,
+    ctx: Optional[tiledb.Ctx] = None,
+) -> GeoDataFrame:
+    df = tiledb.open_dataframe(uri, attrs=columns, use_arrow=False, ctx=ctx)
+    new_columns = {}
+    for name, column in df.iteritems():
+        if isinstance(column.dtype, FlatGeometryDtype):
+            new_columns[name] = column.astype(column.dtype.geometry_dtype)
+        else:
+            new_columns[name] = column
+
+    return GeoDataFrame(new_columns, index=df.index)

--- a/spatialpandas/tests/geometry/strategies.py
+++ b/spatialpandas/tests/geometry/strategies.py
@@ -1,5 +1,4 @@
 import numpy as np
-from geopandas import GeoSeries
 from geopandas.array import from_shapely
 from hypothesis import HealthCheck, settings
 from hypothesis import strategies as st
@@ -29,7 +28,7 @@ st_points = arrays(
 
 
 @st.composite
-def st_point_array(draw, min_size=0, max_size=30, geoseries=False):
+def st_point_array(draw, min_size=0, max_size=30, astype=None):
     n = draw(st.integers(min_size, max_size))
     points = []
     for i in range(n):
@@ -41,13 +40,13 @@ def st_point_array(draw, min_size=0, max_size=30, geoseries=False):
         points.append(sg.Point(point))
 
     result = from_shapely(points)
-    if geoseries:
-        result = GeoSeries(result)
+    if astype:
+        result = astype(result)
     return result
 
 
 @st.composite
-def st_multipoint_array(draw, min_size=0, max_size=30, geoseries=False):
+def st_multipoint_array(draw, min_size=0, max_size=30, astype=None):
     n = draw(st.integers(min_size, max_size))
     lines = []
     for i in range(n):
@@ -60,13 +59,13 @@ def st_multipoint_array(draw, min_size=0, max_size=30, geoseries=False):
         lines.append(sg.MultiPoint(points))
 
     result = from_shapely(lines)
-    if geoseries:
-        result = GeoSeries(result)
+    if astype:
+        result = astype(result)
     return result
 
 
 @st.composite
-def st_line_array(draw, min_size=0, max_size=30, geoseries=False):
+def st_line_array(draw, min_size=0, max_size=30, astype=None):
     n = draw(st.integers(min_size, max_size))
     lines = []
     for i in range(n):
@@ -79,8 +78,8 @@ def st_line_array(draw, min_size=0, max_size=30, geoseries=False):
         lines.append(sg.LineString(points))
 
     result = from_shapely(lines)
-    if geoseries:
-        result = GeoSeries(result)
+    if astype:
+        result = astype(result)
     return result
 
 
@@ -100,7 +99,7 @@ def get_unique_points(
 
 
 @st.composite
-def st_ring_array(draw, min_size=3, max_size=30, geoseries=False):
+def st_ring_array(draw, min_size=3, max_size=30, astype=None):
     assert min_size >= 3
     n = draw(st.integers(min_size, max_size))
     rings = []
@@ -108,13 +107,13 @@ def st_ring_array(draw, min_size=3, max_size=30, geoseries=False):
         rings.append(sg.LinearRing(get_unique_points(n)))
 
     result = from_shapely(rings)
-    if geoseries:
-        result = GeoSeries(result)
+    if astype:
+        result = astype(result)
     return result
 
 
 @st.composite
-def st_multiline_array(draw, min_size=0, max_size=5, geoseries=False):
+def st_multiline_array(draw, min_size=0, max_size=5, astype=None):
     n = draw(st.integers(min_size, max_size))
     multilines = []
     for i in range(n):
@@ -131,8 +130,8 @@ def st_multiline_array(draw, min_size=0, max_size=5, geoseries=False):
         multilines.append(sg.MultiLineString(lines))
 
     result = from_shapely(multilines)
-    if geoseries:
-        result = GeoSeries(result)
+    if astype:
+        result = astype(result)
     return result
 
 
@@ -191,7 +190,7 @@ def st_polygon(draw, n=10, num_holes=None, xmid=0, ymid=0):
 
 
 @st.composite
-def st_polygon_array(draw, min_size=0, max_size=5, geoseries=False):
+def st_polygon_array(draw, min_size=0, max_size=5, astype=None):
     n = draw(st.integers(min_value=min_size, max_value=max_size))
     sg_polygons = [
         draw(st_polygon(xmid=draw(st.floats(-50, 50)), ymid=draw(st.floats(-50, 50))))
@@ -199,13 +198,13 @@ def st_polygon_array(draw, min_size=0, max_size=5, geoseries=False):
     ]
 
     result = from_shapely(sg_polygons)
-    if geoseries:
-        result = GeoSeries(result)
+    if astype:
+        result = astype(result)
     return result
 
 
 @st.composite
-def st_multipolygon_array(draw, min_size=0, max_size=5, geoseries=False):
+def st_multipolygon_array(draw, min_size=0, max_size=5, astype=None):
     n = draw(st.integers(min_value=min_size, max_value=max_size))
     sg_multipolygons = []
     for _ in range(n):
@@ -231,8 +230,8 @@ def st_multipolygon_array(draw, min_size=0, max_size=5, geoseries=False):
         sg_multipolygons.append(sg.MultiPolygon(polygons))
 
     result = from_shapely(sg_multipolygons)
-    if geoseries:
-        result = GeoSeries(result)
+    if astype:
+        result = astype(result)
     return result
 
 

--- a/spatialpandas/tests/geometry/test_cx.py
+++ b/spatialpandas/tests/geometry/test_cx.py
@@ -1,4 +1,5 @@
 import dask.dataframe as dd
+import geopandas as gp
 import pytest
 from hypothesis import given
 from pandas.testing import assert_frame_equal, assert_series_equal
@@ -29,7 +30,7 @@ def get_slices(v0, v1):
 
 
 @pytest.mark.slow
-@given(st_point_array(min_size=1, geoseries=True), st_bounds(orient=True))
+@given(st_point_array(min_size=1, astype=gp.GeoSeries), st_bounds(orient=True))
 @hyp_settings
 def test_point_cx_selection(gp_point, rect):
     x0, y0, x1, y1 = rect
@@ -41,7 +42,7 @@ def test_point_cx_selection(gp_point, rect):
 
 
 @pytest.mark.slow
-@given(st_multipoint_array(min_size=1, geoseries=True), st_bounds(orient=True))
+@given(st_multipoint_array(min_size=1, astype=gp.GeoSeries), st_bounds(orient=True))
 @hyp_settings
 def test_multipoint_cx_selection(gp_multipoint, rect):
     x0, y0, x1, y1 = rect
@@ -53,7 +54,7 @@ def test_multipoint_cx_selection(gp_multipoint, rect):
 
 
 @pytest.mark.slow
-@given(st_line_array(min_size=1, geoseries=True), st_bounds(orient=True))
+@given(st_line_array(min_size=1, astype=gp.GeoSeries), st_bounds(orient=True))
 @hyp_settings
 def test_line_cx_selection(gp_line, rect):
     x0, y0, x1, y1 = rect
@@ -65,7 +66,7 @@ def test_line_cx_selection(gp_line, rect):
 
 
 @pytest.mark.slow
-@given(st_multiline_array(min_size=1, geoseries=True), st_bounds(orient=True))
+@given(st_multiline_array(min_size=1, astype=gp.GeoSeries), st_bounds(orient=True))
 @hyp_settings
 def test_multiline_cx_selection(gp_multiline, rect):
     x0, y0, x1, y1 = rect
@@ -78,7 +79,7 @@ def test_multiline_cx_selection(gp_multiline, rect):
 
 @pytest.mark.slow
 @given(
-    st_polygon_array(min_size=1, geoseries=True),
+    st_polygon_array(min_size=1, astype=gp.GeoSeries),
     st_bounds(
         x_min=-150, x_max=150, y_min=-150, y_max=150, orient=True
     )
@@ -95,7 +96,7 @@ def test_polygon_cx_selection(gp_polygon, rect):
 
 @pytest.mark.slow
 @given(
-    st_multipolygon_array(min_size=1, geoseries=True),
+    st_multipolygon_array(min_size=1, astype=gp.GeoSeries),
     st_bounds(
         x_min=-150, x_max=150, y_min=-150, y_max=150, orient=True
     )
@@ -114,7 +115,7 @@ def test_multipolygon_cx_selection(gp_multipolygon, rect):
             assert all(expected == result)
 
 
-@given(st_multipoint_array(min_size=1, geoseries=True), st_bounds(orient=True))
+@given(st_multipoint_array(min_size=1, astype=gp.GeoSeries), st_bounds(orient=True))
 @hyp_settings
 def test_multipoint_cx_series_selection(gp_multipoint, rect):
     x0, y0, x1, y1 = rect
@@ -126,7 +127,7 @@ def test_multipoint_cx_series_selection(gp_multipoint, rect):
 
 
 @pytest.mark.slow
-@given(st_multipoint_array(min_size=6, geoseries=True), st_bounds(orient=True))
+@given(st_multipoint_array(min_size=6, astype=gp.GeoSeries), st_bounds(orient=True))
 @hyp_settings
 def test_multipoint_cx_series_selection_dask(gp_multipoint, rect):
     x0, y0, x1, y1 = rect
@@ -137,7 +138,7 @@ def test_multipoint_cx_series_selection_dask(gp_multipoint, rect):
     assert_series_equal(expected, result, obj='GeoSeries')
 
 
-@given(st_multipoint_array(min_size=1, geoseries=True), st_bounds(orient=True))
+@given(st_multipoint_array(min_size=1, astype=gp.GeoSeries), st_bounds(orient=True))
 @hyp_settings
 def test_multipoint_cx_frame_selection(gp_multipoint, rect):
     x0, y0, x1, y1 = rect
@@ -151,7 +152,7 @@ def test_multipoint_cx_frame_selection(gp_multipoint, rect):
 
 
 @pytest.mark.slow
-@given(st_multipoint_array(min_size=6, geoseries=True), st_bounds(orient=True))
+@given(st_multipoint_array(min_size=6, astype=gp.GeoSeries), st_bounds(orient=True))
 @hyp_settings
 def test_multipoint_cx_frame_selection_dask(gp_multipoint, rect):
     x0, y0, x1, y1 = rect

--- a/spatialpandas/tests/geometry/test_flattened.py
+++ b/spatialpandas/tests/geometry/test_flattened.py
@@ -1,0 +1,45 @@
+import numpy as np
+from hypothesis import given, settings, strategies
+
+from spatialpandas import GeoSeries
+from spatialpandas.geometry.flattened import (
+    flatten_geometry_array,
+    unflatten_geometry_array,
+)
+
+from .strategies import (
+    st_line_array,
+    st_multiline_array,
+    st_multipoint_array,
+    st_multipolygon_array,
+    st_point_array,
+    st_polygon_array,
+    st_ring_array,
+)
+
+
+@given(
+    gp_array=strategies.one_of(
+        st_point_array(min_size=1),
+        st_multipoint_array(min_size=1),
+        st_line_array(min_size=1),
+        st_ring_array(min_size=3),
+        st_multiline_array(min_size=1),
+        st_polygon_array(min_size=1),
+        st_multipolygon_array(min_size=1),
+    )
+)
+@settings(deadline=None, max_examples=100)
+def test_flatten_unflatten(gp_array):
+    sp_array = GeoSeries(gp_array).values
+
+    flattened = flatten_geometry_array(sp_array)
+    assert flattened.shape == sp_array.shape
+    for flat_array in flattened:
+        assert flat_array.ndim == 1
+        assert flat_array.dtype == sp_array.dtype.subtype
+
+    unflattened = unflatten_geometry_array(flattened, sp_array.dtype)
+    assert sp_array.__class__ is unflattened.__class__
+    assert sp_array.dtype == unflattened.dtype
+    np.testing.assert_array_equal(sp_array, unflattened)

--- a/spatialpandas/tests/geometry/test_to_geopandas.py
+++ b/spatialpandas/tests/geometry/test_to_geopandas.py
@@ -1,4 +1,5 @@
 import pytest
+import geopandas as gp
 from hypothesis import given
 from pandas.testing import assert_series_equal
 
@@ -15,35 +16,35 @@ from .strategies import (
 from spatialpandas import GeoSeries
 
 
-@given(st_point_array(geoseries=True))
+@given(st_point_array(astype=gp.GeoSeries))
 @hyp_settings
 def test_point_array_to_geopandas(gp_point):
     result = GeoSeries(gp_point, dtype='point').to_geopandas()
     assert_series_equal(result, gp_point)
 
 
-@given(st_multipoint_array(geoseries=True))
+@given(st_multipoint_array(astype=gp.GeoSeries))
 @hyp_settings
 def test_multipoint_array_to_geopandas(gp_multipoint):
     result = GeoSeries(gp_multipoint, dtype='multipoint').to_geopandas()
     assert_series_equal(result, gp_multipoint)
 
 
-@given(st_line_array(geoseries=True))
+@given(st_line_array(astype=gp.GeoSeries))
 @hyp_settings
 def test_line_array_to_geopandas(gp_line):
     result = GeoSeries(gp_line, dtype='line').to_geopandas()
     assert_series_equal(result, gp_line)
 
 
-@given(st_ring_array(geoseries=True))
+@given(st_ring_array(astype=gp.GeoSeries))
 @hyp_settings
 def test_ring_array_to_geopandas(gp_ring):
     result = GeoSeries(gp_ring, dtype='ring').to_geopandas()
     assert_series_equal(result, gp_ring)
 
 
-@given(st_multiline_array(geoseries=True))
+@given(st_multiline_array(astype=gp.GeoSeries))
 @hyp_settings
 def test_multiline_array_to_geopandas(gp_multiline):
     result = GeoSeries(gp_multiline, dtype='multiline').to_geopandas()
@@ -51,7 +52,7 @@ def test_multiline_array_to_geopandas(gp_multiline):
 
 
 @pytest.mark.slow
-@given(st_polygon_array(geoseries=True))
+@given(st_polygon_array(astype=gp.GeoSeries))
 @hyp_settings
 def test_polygon_array_to_geopandas(gp_polygon):
     result = GeoSeries(gp_polygon, dtype='polygon').to_geopandas()
@@ -59,7 +60,7 @@ def test_polygon_array_to_geopandas(gp_polygon):
 
 
 @pytest.mark.slow
-@given(st_multipolygon_array(geoseries=True))
+@given(st_multipolygon_array(astype=gp.GeoSeries))
 @hyp_settings
 def test_multipolygon_array_to_geopandas(gp_multipolygon):
     result = GeoSeries(gp_multipolygon, dtype='multipolygon').to_geopandas()

--- a/spatialpandas/tests/test_parquet.py
+++ b/spatialpandas/tests/test_parquet.py
@@ -26,9 +26,9 @@ hyp_settings = settings(
 
 
 @given(
-    gp_point=st_point_array(min_size=1, geoseries=True),
-    gp_multipoint=st_multipoint_array(min_size=1, geoseries=True),
-    gp_multiline=st_multiline_array(min_size=1, geoseries=True),
+    gp_point=st_point_array(min_size=1, astype=GeoSeries),
+    gp_multipoint=st_multipoint_array(min_size=1, astype=GeoSeries),
+    gp_multiline=st_multiline_array(min_size=1, astype=GeoSeries),
 )
 @hyp_settings
 def test_parquet(gp_point, gp_multipoint, gp_multiline, tmp_path_factory):
@@ -36,9 +36,9 @@ def test_parquet(gp_point, gp_multipoint, gp_multiline, tmp_path_factory):
         # Build dataframe
         n = min(len(gp_multipoint), len(gp_multiline))
         df = GeoDataFrame({
-            'point': GeoSeries(gp_point[:n]),
-            'multipoint': GeoSeries(gp_multipoint[:n]),
-            'multiline': GeoSeries(gp_multiline[:n]),
+            'point': gp_point[:n],
+            'multipoint': gp_multipoint[:n],
+            'multiline': gp_multiline[:n],
             'a': list(range(n))
         })
 
@@ -53,9 +53,9 @@ def test_parquet(gp_point, gp_multipoint, gp_multiline, tmp_path_factory):
 
 
 @given(
-    gp_point=st_point_array(min_size=1, geoseries=True),
-    gp_multipoint=st_multipoint_array(min_size=1, geoseries=True),
-    gp_multiline=st_multiline_array(min_size=1, geoseries=True),
+    gp_point=st_point_array(min_size=1, astype=GeoSeries),
+    gp_multipoint=st_multipoint_array(min_size=1, astype=GeoSeries),
+    gp_multiline=st_multiline_array(min_size=1, astype=GeoSeries),
 )
 @hyp_settings
 def test_parquet_columns(gp_point, gp_multipoint, gp_multiline,
@@ -64,9 +64,9 @@ def test_parquet_columns(gp_point, gp_multipoint, gp_multiline,
         # Build dataframe
         n = min(len(gp_multipoint), len(gp_multiline))
         df = GeoDataFrame({
-            'point': GeoSeries(gp_point[:n]),
-            'multipoint': GeoSeries(gp_multipoint[:n]),
-            'multiline': GeoSeries(gp_multiline[:n]),
+            'point': gp_point[:n],
+            'multipoint': gp_multipoint[:n],
+            'multiline': gp_multiline[:n],
             'a': list(range(n))
         })
 
@@ -79,8 +79,8 @@ def test_parquet_columns(gp_point, gp_multipoint, gp_multiline,
 
 
 @given(
-    gp_multipoint=st_multipoint_array(min_size=1, geoseries=True),
-    gp_multiline=st_multiline_array(min_size=1, geoseries=True),
+    gp_multipoint=st_multipoint_array(min_size=1, astype=GeoSeries),
+    gp_multiline=st_multiline_array(min_size=1, astype=GeoSeries),
 )
 @hyp_settings
 def test_parquet_dask(gp_multipoint, gp_multiline, tmp_path_factory):
@@ -88,8 +88,8 @@ def test_parquet_dask(gp_multipoint, gp_multiline, tmp_path_factory):
         # Build dataframe
         n = min(len(gp_multipoint), len(gp_multiline))
         df = GeoDataFrame({
-            'points': GeoSeries(gp_multipoint[:n]),
-            'lines': GeoSeries(gp_multiline[:n]),
+            'points': gp_multipoint[:n],
+            'lines': gp_multiline[:n],
             'a': list(range(n))
         })
         ddf = dd.from_pandas(df, npartitions=3)
@@ -129,16 +129,16 @@ def test_parquet_dask(gp_multipoint, gp_multiline, tmp_path_factory):
 
 
 @given(
-    gp_multipoint=st_multipoint_array(min_size=10, max_size=40, geoseries=True),
-    gp_multiline=st_multiline_array(min_size=10, max_size=40, geoseries=True),
+    gp_multipoint=st_multipoint_array(min_size=10, max_size=40, astype=GeoSeries),
+    gp_multiline=st_multiline_array(min_size=10, max_size=40, astype=GeoSeries),
 )
 @settings(deadline=None, max_examples=30)
 def test_pack_partitions(gp_multipoint, gp_multiline):
     # Build dataframe
     n = min(len(gp_multipoint), len(gp_multiline))
     df = GeoDataFrame({
-        'points': GeoSeries(gp_multipoint[:n]),
-        'lines': GeoSeries(gp_multiline[:n]),
+        'points': gp_multipoint[:n],
+        'lines': gp_multiline[:n],
         'a': list(range(n))
     }).set_geometry('lines')
     ddf = dd.from_pandas(df, npartitions=3)
@@ -165,8 +165,8 @@ def test_pack_partitions(gp_multipoint, gp_multiline):
 
 @pytest.mark.slow
 @given(
-    gp_multipoint=st_multipoint_array(min_size=60, max_size=100, geoseries=True),
-    gp_multiline=st_multiline_array(min_size=60, max_size=100, geoseries=True),
+    gp_multipoint=st_multipoint_array(min_size=60, max_size=100, astype=GeoSeries),
+    gp_multiline=st_multiline_array(min_size=60, max_size=100, astype=GeoSeries),
     use_temp_format=hs.booleans()
 )
 @settings(
@@ -187,8 +187,8 @@ def test_pack_partitions_to_parquet(gp_multipoint, gp_multiline,
         # Build dataframe
         n = min(len(gp_multipoint), len(gp_multiline))
         df = GeoDataFrame({
-            'points': GeoSeries(gp_multipoint[:n]),
-            'lines': GeoSeries(gp_multiline[:n]),
+            'points': gp_multipoint[:n],
+            'lines': gp_multiline[:n],
             'a': list(range(n))
         }).set_geometry('lines')
         ddf = dd.from_pandas(df, npartitions=3)
@@ -240,10 +240,10 @@ def test_pack_partitions_to_parquet(gp_multipoint, gp_multiline,
 
 @pytest.mark.slow
 @given(
-    gp_multipoint1=st_multipoint_array(min_size=10, max_size=40, geoseries=True),
-    gp_multiline1=st_multiline_array(min_size=10, max_size=40, geoseries=True),
-    gp_multipoint2=st_multipoint_array(min_size=10, max_size=40, geoseries=True),
-    gp_multiline2=st_multiline_array(min_size=10, max_size=40, geoseries=True),
+    gp_multipoint1=st_multipoint_array(min_size=10, max_size=40, astype=GeoSeries),
+    gp_multiline1=st_multiline_array(min_size=10, max_size=40, astype=GeoSeries),
+    gp_multipoint2=st_multipoint_array(min_size=10, max_size=40, astype=GeoSeries),
+    gp_multiline2=st_multiline_array(min_size=10, max_size=40, astype=GeoSeries),
 )
 @settings(deadline=None, max_examples=30, suppress_health_check=[HealthCheck.too_slow])
 def test_pack_partitions_to_parquet_glob(gp_multipoint1, gp_multiline1,
@@ -253,8 +253,8 @@ def test_pack_partitions_to_parquet_glob(gp_multipoint1, gp_multiline1,
         # Build dataframe1
         n = min(len(gp_multipoint1), len(gp_multiline1))
         df1 = GeoDataFrame({
-            'points': GeoSeries(gp_multipoint1[:n]),
-            'lines': GeoSeries(gp_multiline1[:n]),
+            'points': gp_multipoint1[:n],
+            'lines': gp_multiline1[:n],
             'a': list(range(n))
         }).set_geometry('lines')
         ddf1 = dd.from_pandas(df1, npartitions=3)
@@ -264,8 +264,8 @@ def test_pack_partitions_to_parquet_glob(gp_multipoint1, gp_multiline1,
         # Build dataframe2
         n = min(len(gp_multipoint2), len(gp_multiline2))
         df2 = GeoDataFrame({
-            'points': GeoSeries(gp_multipoint2[:n]),
-            'lines': GeoSeries(gp_multiline2[:n]),
+            'points': gp_multipoint2[:n],
+            'lines': gp_multiline2[:n],
             'a': list(range(n))
         }).set_geometry('lines')
         ddf2 = dd.from_pandas(df2, npartitions=3)
@@ -309,10 +309,10 @@ def test_pack_partitions_to_parquet_glob(gp_multipoint1, gp_multiline1,
 
 @pytest.mark.slow
 @given(
-    gp_multipoint1=st_multipoint_array(min_size=10, max_size=40, geoseries=True),
-    gp_multiline1=st_multiline_array(min_size=10, max_size=40, geoseries=True),
-    gp_multipoint2=st_multipoint_array(min_size=10, max_size=40, geoseries=True),
-    gp_multiline2=st_multiline_array(min_size=10, max_size=40, geoseries=True),
+    gp_multipoint1=st_multipoint_array(min_size=10, max_size=40, astype=GeoSeries),
+    gp_multiline1=st_multiline_array(min_size=10, max_size=40, astype=GeoSeries),
+    gp_multipoint2=st_multipoint_array(min_size=10, max_size=40, astype=GeoSeries),
+    gp_multiline2=st_multiline_array(min_size=10, max_size=40, astype=GeoSeries),
     bounds=st_bounds(),
 )
 @settings(deadline=None, max_examples=30, suppress_health_check=[HealthCheck.too_slow])
@@ -325,8 +325,8 @@ def test_pack_partitions_to_parquet_list_bounds(
         # Build dataframe1
         n = min(len(gp_multipoint1), len(gp_multiline1))
         df1 = GeoDataFrame({
-            'points': GeoSeries(gp_multipoint1[:n]),
-            'lines': GeoSeries(gp_multiline1[:n]),
+            'points': gp_multipoint1[:n],
+            'lines': gp_multiline1[:n],
             'a': list(range(n))
         }).set_geometry('lines')
         ddf1 = dd.from_pandas(df1, npartitions=3)
@@ -336,8 +336,8 @@ def test_pack_partitions_to_parquet_list_bounds(
         # Build dataframe2
         n = min(len(gp_multipoint2), len(gp_multiline2))
         df2 = GeoDataFrame({
-            'points': GeoSeries(gp_multipoint2[:n]),
-            'lines': GeoSeries(gp_multiline2[:n]),
+            'points': gp_multipoint2[:n],
+            'lines': gp_multiline2[:n],
             'a': list(range(n))
         }).set_geometry('lines')
         ddf2 = dd.from_pandas(df2, npartitions=3)

--- a/spatialpandas/tests/test_parquet.py
+++ b/spatialpandas/tests/test_parquet.py
@@ -6,15 +6,12 @@ import pandas as pd
 import pytest
 from hypothesis import HealthCheck, Phase, Verbosity, given, settings
 
-from .geometry.strategies import (
-    st_bounds,
-    st_multiline_array,
-    st_multipoint_array,
-    st_point_array,
-)
-from spatialpandas import GeoDataFrame, GeoSeries
+from spatialpandas import GeoDataFrame
 from spatialpandas.dask import DaskGeoDataFrame
 from spatialpandas.io import read_parquet, read_parquet_dask, to_parquet
+
+from .geometry.strategies import st_bounds, st_geodataframe
+
 
 dask.config.set(scheduler="single-threaded")
 
@@ -25,122 +22,59 @@ hyp_settings = settings(
 )
 
 
-@given(
-    gp_point=st_point_array(min_size=1, astype=GeoSeries),
-    gp_multipoint=st_multipoint_array(min_size=1, astype=GeoSeries),
-    gp_multiline=st_multiline_array(min_size=1, astype=GeoSeries),
-)
+@given(df=st_geodataframe())
 @hyp_settings
-def test_parquet(gp_point, gp_multipoint, gp_multiline, tmp_path_factory):
+def test_parquet(df, tmp_path_factory):
+    df.index.name = "range_idx"
     with tmp_path_factory.mktemp("spatialpandas", numbered=True) as tmp_path:
-        # Build dataframe
-        n = min(len(gp_multipoint), len(gp_multiline))
-        df = GeoDataFrame({
-            'point': gp_point[:n],
-            'multipoint': gp_multipoint[:n],
-            'multiline': gp_multiline[:n],
-            'a': list(range(n))
-        })
-
-        df.index.name = 'range_idx'
-
-        path = tmp_path / 'df.parq'
+        path = tmp_path / "df.parq"
         to_parquet(df, path)
-        df_read = read_parquet(str(path), columns=['point', 'multipoint', 'multiline', 'a'])
+
+        df_read = read_parquet(path)
         assert isinstance(df_read, GeoDataFrame)
         pd.testing.assert_frame_equal(df, df_read)
-        assert df_read.index.name == df.index.name
 
-
-@given(
-    gp_point=st_point_array(min_size=1, astype=GeoSeries),
-    gp_multipoint=st_multipoint_array(min_size=1, astype=GeoSeries),
-    gp_multiline=st_multiline_array(min_size=1, astype=GeoSeries),
-)
-@hyp_settings
-def test_parquet_columns(gp_point, gp_multipoint, gp_multiline,
-                         tmp_path_factory):
-    with tmp_path_factory.mktemp("spatialpandas", numbered=True) as tmp_path:
-        # Build dataframe
-        n = min(len(gp_multipoint), len(gp_multiline))
-        df = GeoDataFrame({
-            'point': gp_point[:n],
-            'multipoint': gp_multipoint[:n],
-            'multiline': gp_multiline[:n],
-            'a': list(range(n))
-        })
-
-        path = tmp_path / 'df.parq'
-        to_parquet(df, path)
-        columns = ['a', 'multiline']
+        columns = ["a", "multilines", "polygons"]
         df_read = read_parquet(str(path), columns=columns)
         assert isinstance(df_read, GeoDataFrame)
         pd.testing.assert_frame_equal(df[columns], df_read)
 
 
-@given(
-    gp_multipoint=st_multipoint_array(min_size=1, astype=GeoSeries),
-    gp_multiline=st_multiline_array(min_size=1, astype=GeoSeries),
-)
+@given(df=st_geodataframe(column_names=("points", "lines", "a")))
 @hyp_settings
-def test_parquet_dask(gp_multipoint, gp_multiline, tmp_path_factory):
+def test_parquet_dask(df, tmp_path_factory):
     with tmp_path_factory.mktemp("spatialpandas", numbered=True) as tmp_path:
-        # Build dataframe
-        n = min(len(gp_multipoint), len(gp_multiline))
-        df = GeoDataFrame({
-            'points': gp_multipoint[:n],
-            'lines': gp_multiline[:n],
-            'a': list(range(n))
-        })
         ddf = dd.from_pandas(df, npartitions=3)
 
-        path = tmp_path / 'ddf.parq'
+        path = tmp_path / "ddf.parq"
         ddf.to_parquet(str(path))
         ddf_read = read_parquet_dask(str(path))
 
-        # Check type
         assert isinstance(ddf_read, DaskGeoDataFrame)
+        assert ddf_read.geometry.name == "points"
 
         # Check that partition bounds were loaded
-        nonempty = np.nonzero(
-            np.asarray(ddf.map_partitions(len).compute() > 0)
-        )[0]
-        assert set(ddf_read._partition_bounds) == {'points', 'lines'}
-        expected_partition_bounds = (
-            ddf['points'].partition_bounds.iloc[nonempty].reset_index(drop=True)
-        )
-        expected_partition_bounds.index.name = 'partition'
-
-        pd.testing.assert_frame_equal(
-            expected_partition_bounds,
-            ddf_read._partition_bounds['points'],
-        )
-
-        expected_partition_bounds = (
-            ddf['lines'].partition_bounds.iloc[nonempty].reset_index(drop=True)
-        )
-        expected_partition_bounds.index.name = 'partition'
-        pd.testing.assert_frame_equal(
-            expected_partition_bounds,
-            ddf_read._partition_bounds['lines'],
-        )
-
-        assert ddf_read.geometry.name == 'points'
+        assert set(ddf_read._partition_bounds) == {"points", "lines"}
+        nonempty = np.nonzero(np.asarray(ddf.map_partitions(len).compute() > 0))[0]
+        for column in "points", "lines":
+            expected_partition_bounds = (
+                ddf[column].partition_bounds.iloc[nonempty].reset_index(drop=True)
+            )
+            expected_partition_bounds.index.name = "partition"
+            pd.testing.assert_frame_equal(
+                expected_partition_bounds,
+                ddf_read._partition_bounds[column],
+            )
 
 
 @given(
-    gp_multipoint=st_multipoint_array(min_size=10, max_size=40, astype=GeoSeries),
-    gp_multiline=st_multiline_array(min_size=10, max_size=40, astype=GeoSeries),
+    st_geodataframe(
+        min_size=10, max_size=40, column_names=("multipoints", "multilines", "a")
+    )
 )
 @settings(deadline=None, max_examples=30)
-def test_pack_partitions(gp_multipoint, gp_multiline):
-    # Build dataframe
-    n = min(len(gp_multipoint), len(gp_multiline))
-    df = GeoDataFrame({
-        'points': gp_multipoint[:n],
-        'lines': gp_multiline[:n],
-        'a': list(range(n))
-    }).set_geometry('lines')
+def test_pack_partitions(df):
+    df = df.set_geometry("multilines")
     ddf = dd.from_pandas(df, npartitions=3)
 
     # Pack partitions
@@ -150,14 +84,18 @@ def test_pack_partitions(gp_multipoint, gp_multiline):
     assert ddf_packed.npartitions == 4
 
     # Check that rows are now sorted in order of hilbert distance
-    total_bounds = df.lines.total_bounds
-    hilbert_distances = ddf_packed.lines.map_partitions(
-        lambda s: s.hilbert_distance(total_bounds=total_bounds)
-    ).compute().values
+    total_bounds = df.multilines.total_bounds
+    hilbert_distances = (
+        ddf_packed.multilines.map_partitions(
+            lambda s: s.hilbert_distance(total_bounds=total_bounds)
+        )
+        .compute()
+        .values
+    )
 
     # Compute expected total_bounds
     expected_distances = np.sort(
-        df.lines.hilbert_distance(total_bounds=total_bounds).values
+        df.multilines.hilbert_distance(total_bounds=total_bounds).values
     )
 
     np.testing.assert_equal(expected_distances, hilbert_distances)
@@ -165,45 +103,34 @@ def test_pack_partitions(gp_multipoint, gp_multiline):
 
 @pytest.mark.slow
 @given(
-    gp_multipoint=st_multipoint_array(min_size=60, max_size=100, astype=GeoSeries),
-    gp_multiline=st_multiline_array(min_size=60, max_size=100, astype=GeoSeries),
-    use_temp_format=hs.booleans()
+    df=st_geodataframe(
+        min_size=60, max_size=100, column_names=("multipoints", "multilines", "a")
+    ),
+    use_temp_format=hs.booleans(),
 )
 @settings(
     deadline=None,
     max_examples=30,
     suppress_health_check=[HealthCheck.too_slow],
-    phases=[
-        Phase.explicit,
-        Phase.reuse,
-        Phase.generate,
-        Phase.target
-    ],
+    phases=[Phase.explicit, Phase.reuse, Phase.generate, Phase.target],
     verbosity=Verbosity.verbose,
 )
-def test_pack_partitions_to_parquet(gp_multipoint, gp_multiline,
-                                    use_temp_format, tmp_path_factory):
+def test_pack_partitions_to_parquet(df, use_temp_format, tmp_path_factory):
     with tmp_path_factory.mktemp("spatialpandas", numbered=True) as tmp_path:
-        # Build dataframe
-        n = min(len(gp_multipoint), len(gp_multiline))
-        df = GeoDataFrame({
-            'points': gp_multipoint[:n],
-            'lines': gp_multiline[:n],
-            'a': list(range(n))
-        }).set_geometry('lines')
+        df = df.set_geometry("multilines")
         ddf = dd.from_pandas(df, npartitions=3)
 
-        path = tmp_path / 'ddf.parq'
+        path = tmp_path / "ddf.parq"
         if use_temp_format:
-            (tmp_path / 'scratch').mkdir(parents=True, exist_ok=True)
-            tempdir_format = str(tmp_path / 'scratch' / 'part-{uuid}-{partition:03d}')
+            (tmp_path / "scratch").mkdir(parents=True, exist_ok=True)
+            tempdir_format = str(tmp_path / "scratch" / "part-{uuid}-{partition:03d}")
         else:
             tempdir_format = None
 
         _retry_args = dict(
             wait_exponential_multiplier=10,
             wait_exponential_max=20000,
-            stop_max_attempt_number=4
+            stop_max_attempt_number=4,
         )
 
         ddf_packed = ddf.pack_partitions_to_parquet(
@@ -217,21 +144,25 @@ def test_pack_partitions_to_parquet(gp_multipoint, gp_multiline,
         assert ddf_packed.npartitions <= 12
 
         # Check that rows are now sorted in order of hilbert distance
-        total_bounds = df.lines.total_bounds
-        hilbert_distances = ddf_packed.lines.map_partitions(
-            lambda s: s.hilbert_distance(total_bounds=total_bounds)
-        ).compute().values
+        total_bounds = df.multilines.total_bounds
+        hilbert_distances = (
+            ddf_packed.multilines.map_partitions(
+                lambda s: s.hilbert_distance(total_bounds=total_bounds)
+            )
+            .compute()
+            .values
+        )
 
         # Compute expected total_bounds
         expected_distances = np.sort(
-            df.lines.hilbert_distance(total_bounds=total_bounds).values
+            df.multilines.hilbert_distance(total_bounds=total_bounds).values
         )
 
         np.testing.assert_equal(expected_distances, hilbert_distances)
-        assert ddf_packed.geometry.name == 'points'
+        assert ddf_packed.geometry.name == "multipoints"
 
         # Read columns
-        columns = ['a', 'lines']
+        columns = ["a", "multilines"]
         ddf_read_cols = read_parquet_dask(path, columns=columns)
         pd.testing.assert_frame_equal(
             ddf_read_cols.compute(), ddf_packed[columns].compute()
@@ -240,40 +171,28 @@ def test_pack_partitions_to_parquet(gp_multipoint, gp_multiline,
 
 @pytest.mark.slow
 @given(
-    gp_multipoint1=st_multipoint_array(min_size=10, max_size=40, astype=GeoSeries),
-    gp_multiline1=st_multiline_array(min_size=10, max_size=40, astype=GeoSeries),
-    gp_multipoint2=st_multipoint_array(min_size=10, max_size=40, astype=GeoSeries),
-    gp_multiline2=st_multiline_array(min_size=10, max_size=40, astype=GeoSeries),
+    df1=st_geodataframe(
+        min_size=10, max_size=40, column_names=("multipoints", "multilines", "a")
+    ),
+    df2=st_geodataframe(
+        min_size=10, max_size=40, column_names=("multipoints", "multilines", "a")
+    ),
 )
 @settings(deadline=None, max_examples=30, suppress_health_check=[HealthCheck.too_slow])
-def test_pack_partitions_to_parquet_glob(gp_multipoint1, gp_multiline1,
-                                         gp_multipoint2, gp_multiline2,
-                                         tmp_path_factory):
+def test_pack_partitions_to_parquet_glob(df1, df2, tmp_path_factory):
     with tmp_path_factory.mktemp("spatialpandas", numbered=True) as tmp_path:
-        # Build dataframe1
-        n = min(len(gp_multipoint1), len(gp_multiline1))
-        df1 = GeoDataFrame({
-            'points': gp_multipoint1[:n],
-            'lines': gp_multiline1[:n],
-            'a': list(range(n))
-        }).set_geometry('lines')
+        df1 = df1.set_geometry("multilines")
         ddf1 = dd.from_pandas(df1, npartitions=3)
-        path1 = tmp_path / 'ddf1.parq'
+        path1 = tmp_path / "ddf1.parq"
         ddf_packed1 = ddf1.pack_partitions_to_parquet(str(path1), npartitions=3)
 
-        # Build dataframe2
-        n = min(len(gp_multipoint2), len(gp_multiline2))
-        df2 = GeoDataFrame({
-            'points': gp_multipoint2[:n],
-            'lines': gp_multiline2[:n],
-            'a': list(range(n))
-        }).set_geometry('lines')
+        df2 = df2.set_geometry("multilines")
         ddf2 = dd.from_pandas(df2, npartitions=3)
-        path2 = tmp_path / 'ddf2.parq'
+        path2 = tmp_path / "ddf2.parq"
         ddf_packed2 = ddf2.pack_partitions_to_parquet(str(path2), npartitions=4)
 
         # Load both packed datasets with glob
-        ddf_globbed = read_parquet_dask(tmp_path / "ddf*.parq", geometry="lines")
+        ddf_globbed = read_parquet_dask(tmp_path / "ddf*.parq", geometry="multilines")
 
         # Check the number of partitions (< 7 can happen in the case of empty partitions)
         assert ddf_globbed.npartitions <= 7
@@ -285,69 +204,60 @@ def test_pack_partitions_to_parquet_glob(gp_multipoint1, gp_multiline1,
 
         # Check partition bounds
         expected_bounds = {
-            'points': pd.concat([
-                ddf_packed1._partition_bounds['points'],
-                ddf_packed2._partition_bounds['points'],
-            ]).reset_index(drop=True),
-            'lines': pd.concat([
-                ddf_packed1._partition_bounds['lines'],
-                ddf_packed2._partition_bounds['lines'],
-            ]).reset_index(drop=True),
+            "multipoints": pd.concat(
+                [
+                    ddf_packed1._partition_bounds["multipoints"],
+                    ddf_packed2._partition_bounds["multipoints"],
+                ]
+            ).reset_index(drop=True),
+            "multilines": pd.concat(
+                [
+                    ddf_packed1._partition_bounds["multilines"],
+                    ddf_packed2._partition_bounds["multilines"],
+                ]
+            ).reset_index(drop=True),
         }
-        expected_bounds['points'].index.name = 'partition'
-        expected_bounds['lines'].index.name = 'partition'
+        expected_bounds["multipoints"].index.name = "partition"
+        expected_bounds["multilines"].index.name = "partition"
         pd.testing.assert_frame_equal(
-            expected_bounds['points'], ddf_globbed._partition_bounds['points']
+            expected_bounds["multipoints"], ddf_globbed._partition_bounds["multipoints"]
         )
 
         pd.testing.assert_frame_equal(
-            expected_bounds['lines'], ddf_globbed._partition_bounds['lines']
+            expected_bounds["multilines"], ddf_globbed._partition_bounds["multilines"]
         )
 
-        assert ddf_globbed.geometry.name == 'lines'
+        assert ddf_globbed.geometry.name == "multilines"
 
 
 @pytest.mark.slow
 @given(
-    gp_multipoint1=st_multipoint_array(min_size=10, max_size=40, astype=GeoSeries),
-    gp_multiline1=st_multiline_array(min_size=10, max_size=40, astype=GeoSeries),
-    gp_multipoint2=st_multipoint_array(min_size=10, max_size=40, astype=GeoSeries),
-    gp_multiline2=st_multiline_array(min_size=10, max_size=40, astype=GeoSeries),
+    df1=st_geodataframe(
+        min_size=10, max_size=40, column_names=("multipoints", "multilines", "a")
+    ),
+    df2=st_geodataframe(
+        min_size=10, max_size=40, column_names=("multipoints", "multilines", "a")
+    ),
     bounds=st_bounds(),
 )
 @settings(deadline=None, max_examples=30, suppress_health_check=[HealthCheck.too_slow])
-def test_pack_partitions_to_parquet_list_bounds(
-        gp_multipoint1, gp_multiline1,
-        gp_multipoint2, gp_multiline2,
-        bounds, tmp_path_factory,
-):
+def test_pack_partitions_to_parquet_list_bounds(df1, df2, bounds, tmp_path_factory):
     with tmp_path_factory.mktemp("spatialpandas", numbered=True) as tmp_path:
-        # Build dataframe1
-        n = min(len(gp_multipoint1), len(gp_multiline1))
-        df1 = GeoDataFrame({
-            'points': gp_multipoint1[:n],
-            'lines': gp_multiline1[:n],
-            'a': list(range(n))
-        }).set_geometry('lines')
+        df1 = df1.set_geometry("multilines")
         ddf1 = dd.from_pandas(df1, npartitions=3)
-        path1 = tmp_path / 'ddf1.parq'
+        path1 = tmp_path / "ddf1.parq"
         ddf_packed1 = ddf1.pack_partitions_to_parquet(str(path1), npartitions=3)
 
-        # Build dataframe2
-        n = min(len(gp_multipoint2), len(gp_multiline2))
-        df2 = GeoDataFrame({
-            'points': gp_multipoint2[:n],
-            'lines': gp_multiline2[:n],
-            'a': list(range(n))
-        }).set_geometry('lines')
+        df2 = df2.set_geometry("multilines")
         ddf2 = dd.from_pandas(df2, npartitions=3)
-        path2 = tmp_path / 'ddf2.parq'
+        path2 = tmp_path / "ddf2.parq"
         ddf_packed2 = ddf2.pack_partitions_to_parquet(str(path2), npartitions=4)
 
         # Load both packed datasets with glob
         ddf_read = read_parquet_dask(
             [str(tmp_path / "ddf1.parq"), str(tmp_path / "ddf2.parq")],
-            geometry="points", bounds=bounds
+            geometry="multipoints",
+            bounds=bounds,
         )
 
         # Check the number of partitions (< 7 can happen in the case of empty partitions)
@@ -356,45 +266,55 @@ def test_pack_partitions_to_parquet_list_bounds(
         # Check contents
         xslice = slice(bounds[0], bounds[2])
         yslice = slice(bounds[1], bounds[3])
-        expected_df = pd.concat([
-            ddf_packed1.cx_partitions[xslice, yslice].compute(),
-            ddf_packed2.cx_partitions[xslice, yslice].compute()
-        ])
+        expected_df = pd.concat(
+            [
+                ddf_packed1.cx_partitions[xslice, yslice].compute(),
+                ddf_packed2.cx_partitions[xslice, yslice].compute(),
+            ]
+        )
         df_read = ddf_read.compute()
         pd.testing.assert_frame_equal(df_read, expected_df)
 
         # Compute expected partition bounds
-        points_bounds = pd.concat([
-            ddf_packed1._partition_bounds['points'],
-            ddf_packed2._partition_bounds['points'],
-        ]).reset_index(drop=True)
+        points_bounds = pd.concat(
+            [
+                ddf_packed1._partition_bounds["multipoints"],
+                ddf_packed2._partition_bounds["multipoints"],
+            ]
+        ).reset_index(drop=True)
 
         x0, y0, x1, y1 = bounds
         x0, x1 = (x0, x1) if x0 <= x1 else (x1, x0)
         y0, y1 = (y0, y1) if y0 <= y1 else (y1, y0)
         partition_inds = ~(
-            (points_bounds.x1 < x0) |
-            (points_bounds.y1 < y0) |
-            (points_bounds.x0 > x1) |
-            (points_bounds.y0 > y1)
+            (points_bounds.x1 < x0)
+            | (points_bounds.y1 < y0)
+            | (points_bounds.x0 > x1)
+            | (points_bounds.y0 > y1)
         )
         points_bounds = points_bounds[partition_inds].reset_index(drop=True)
 
-        lines_bounds = pd.concat([
-            ddf_packed1._partition_bounds['lines'],
-            ddf_packed2._partition_bounds['lines'],
-        ]).reset_index(drop=True)[partition_inds].reset_index(drop=True)
-        points_bounds.index.name = 'partition'
-        lines_bounds.index.name = 'partition'
+        lines_bounds = (
+            pd.concat(
+                [
+                    ddf_packed1._partition_bounds["multilines"],
+                    ddf_packed2._partition_bounds["multilines"],
+                ]
+            )
+            .reset_index(drop=True)[partition_inds]
+            .reset_index(drop=True)
+        )
+        points_bounds.index.name = "partition"
+        lines_bounds.index.name = "partition"
 
         # Check partition bounds
         pd.testing.assert_frame_equal(
-            points_bounds, ddf_read._partition_bounds['points']
+            points_bounds, ddf_read._partition_bounds["multipoints"]
         )
 
         pd.testing.assert_frame_equal(
-            lines_bounds, ddf_read._partition_bounds['lines']
+            lines_bounds, ddf_read._partition_bounds["multilines"]
         )
 
         # Check active geometry column
-        assert ddf_read.geometry.name == 'points'
+        assert ddf_read.geometry.name == "multipoints"

--- a/spatialpandas/tests/test_tiledb.py
+++ b/spatialpandas/tests/test_tiledb.py
@@ -1,0 +1,31 @@
+import pandas as pd
+from hypothesis import HealthCheck, given, settings
+
+from spatialpandas import GeoDataFrame
+from spatialpandas.io import read_tiledb, to_tiledb
+
+from .geometry.strategies import st_geodataframe
+
+hyp_settings = settings(
+    deadline=None,
+    max_examples=100,
+    suppress_health_check=[HealthCheck.too_slow],
+)
+
+
+@given(df=st_geodataframe())
+@hyp_settings
+def test_tiledb(df, tmp_path_factory):
+    df.index.name = "range_idx"
+    with tmp_path_factory.mktemp("spatialpandas", numbered=True) as tmp_path:
+        uri = str(tmp_path / "df.tdb")
+        to_tiledb(df, uri)
+
+        df_read = read_tiledb(uri)
+        assert isinstance(df_read, GeoDataFrame)
+        pd.testing.assert_frame_equal(df, df_read)
+
+        columns = ["a", "multilines", "polygons"]
+        df_read = read_tiledb(uri, columns=columns)
+        assert isinstance(df_read, GeoDataFrame)
+        pd.testing.assert_frame_equal(df[columns], df_read)

--- a/spatialpandas/tests/tools/test_sjoin.py
+++ b/spatialpandas/tests/tools/test_sjoin.py
@@ -28,8 +28,8 @@ if not gpd_spatialindex:
 
 
 @given(
-    st_point_array(min_size=1, geoseries=True),
-    st_polygon_array(min_size=1, geoseries=True),
+    st_point_array(min_size=1),
+    st_polygon_array(min_size=1),
     hs.sampled_from(["inner", "left", "right"])
 )
 @hyp_settings


### PR DESCRIPTION
This PR adds initial support for persisting GeoDataFrames to TileDB. The API is similar to the respective Parquet API:
- `spatialpandas.io.to_tiledb`: Writes a `spatialpandas.GeoDataFrame` to a TileDB array.
- `spatialpandas.io.read_tiledb`: Reads a TileDB array into a `spatialpandas.GeoDataFrame`.

It requires `TileDB-Py>=0.8.6` that adds support for storing Pandas extension types as [variable length attributes](https://github.com/TileDB-Inc/TileDB-Py/pull/515) (plus a [fix](https://github.com/TileDB-Inc/TileDB-Py/pull/518) needed for a unit test).

The relevant implementation has been squashed to 0902b2082a8972c37c5aefbdad3c903e15596761; previous commits are not directly related (PyArrow upgrade, test refactoring).
