### PR TITLE
TileDB integration

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ install_requires = [
     'numba',
     'pandas>=0.25',
     'param',
-    'pyarrow>=0.15',
+    'pyarrow>=1.0',
     'python-snappy',
     'retrying',
 ]

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ install_requires = [
     'pyarrow>=1.0',
     'python-snappy',
     'retrying',
+    'tiledb>=0.8.6',
 ]
 
 # Checking for platform explicitly because

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,9 @@ extras_require = {
         'geopandas',
         'holoviews',
         'matplotlib',
+    ],
+    'tiledb-cloud': [
+        'tiledb-cloud',
     ]
 }
 

--- a/spatialpandas/geometry/flattened.py
+++ b/spatialpandas/geometry/flattened.py
@@ -1,0 +1,170 @@
+import re
+
+import numpy as np
+from pandas.api.extensions import (
+    ExtensionArray,
+    ExtensionDtype,
+    no_default,
+    register_extension_dtype,
+)
+from pandas.api.types import is_dtype_equal
+from pandas.core.dtypes.base import registry
+
+from ..geometry import GeometryArray, GeometryDtype
+from ..geometry.basefixed import GeometryFixed, GeometryFixedArray
+from ..geometry.baselist import GeometryList, GeometryListArray
+
+
+@register_extension_dtype
+class FlatGeometryDtype(ExtensionDtype):
+    _metadata = ("geometry_dtype",)
+
+    type = np.ndarray
+    na_value = None
+
+    def __init__(self, geometry_dtype):
+        self.geometry_dtype = geometry_dtype
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}({self.geometry_dtype})"
+
+    @property
+    def name(self):
+        return f"flat[{self.geometry_dtype}]"
+
+    @property
+    def subtype(self):
+        return self.geometry_dtype.subtype
+
+    @classmethod
+    def construct_array_type(cls):
+        return FlatGeometryArray
+
+    @classmethod
+    def construct_from_string(cls, string):
+        msg = f"Cannot construct a '{cls.__name__}' from '{string}'"
+
+        match = re.match(fr"^flat\[(.+)\]$", string)
+        if match is None:
+            raise TypeError(msg)
+
+        wrapped_dtype = registry.find(match.group(1))
+        if wrapped_dtype is None:
+            raise TypeError(msg)
+
+        try:
+            return cls(wrapped_dtype)
+        except Exception:
+            raise TypeError(msg)
+
+
+class FlatGeometryArray(ExtensionArray):
+    def __init__(self, geometry_array: GeometryArray):
+        self._geometry_array = geometry_array
+        self._dtype = FlatGeometryDtype(geometry_array.dtype)
+
+    @property
+    def dtype(self):
+        return self._dtype
+
+    def __len__(self):
+        return len(self._geometry_array)
+
+    def copy(self):
+        return self.__class__(self._geometry_array)
+
+    def isna(self):
+        return self._geometry_array.isna()
+
+    def to_numpy(self, dtype=None, copy=False, na_value=no_default):
+        result = flatten_geometry_array(self._geometry_array, dtype)
+        if na_value is not no_default:
+            result[self.isna()] = na_value
+        return result
+
+    def astype(self, dtype, copy=True):
+        if is_dtype_equal(dtype, self._dtype.geometry_dtype):
+            return self._geometry_array
+        return super().astype(dtype=dtype, copy=copy)
+
+    @classmethod
+    def _from_sequence(cls, scalars, *, dtype=None, copy=False):
+        if isinstance(scalars, cls):
+            return scalars
+
+        if isinstance(dtype, FlatGeometryDtype):
+            dtype = dtype.geometry_dtype
+
+        if isinstance(scalars, GeometryArray):
+            geometry_array = scalars.astype(dtype, copy=False)
+        elif isinstance(dtype, GeometryDtype):
+            geometry_array = unflatten_geometry_array(scalars, dtype)
+        else:
+            raise TypeError(f"[Flat]GeometryDtype expected, {dtype} passed")
+
+        return cls(geometry_array)
+
+
+def flatten_geometry_array(geometry_array: GeometryArray, dtype=None) -> np.ndarray:
+    if dtype is None:
+        dtype = geometry_array.numpy_dtype
+
+    if isinstance(geometry_array, GeometryFixedArray):
+        flatten = _flatten_fixed_geometry
+    elif isinstance(geometry_array, GeometryListArray):
+        flatten = _flatten_list_geometry
+    else:
+        raise TypeError(f"Flattening '{geometry_array.__class__}' not supported")
+
+    flat_arrays = np.empty(len(geometry_array), dtype="O")
+    for i, geometry in enumerate(geometry_array):
+        if geometry is not None:
+            flat_arrays[i] = flatten(geometry).astype(dtype, copy=False)
+    return flat_arrays
+
+
+def _flatten_fixed_geometry(geometry: GeometryFixed) -> np.ndarray:
+    return geometry.flat_values
+
+
+def _flatten_list_geometry(geometry: GeometryList) -> np.ndarray:
+    # For GeometryList subclasses with 0 nesting levels (MultiPoint, Line, Ring),
+    # `.buffer_offsets` returns a length-1 tuple of offsets that include
+    # all the flat values. These offsets are both unnecessary and mess up the
+    # unflattening by creating an extra nesting level, so ignore them
+    offsets = geometry.buffer_offsets if geometry._nesting_levels > 0 else ()
+    parts = [(len(offsets), *map(len, offsets))]
+    parts.extend(offsets)
+    parts.append(geometry.buffer_values)
+    return np.concatenate(parts)
+
+
+def unflatten_geometry_array(
+    ragged_array: np.ndarray, dtype: GeometryDtype
+) -> GeometryArray:
+    array_type = dtype.construct_array_type()
+
+    if issubclass(array_type, GeometryFixedArray):
+        return array_type(ragged_array)
+
+    if issubclass(array_type, GeometryListArray):
+        sub_arrays_list = []
+        for flat_array in ragged_array:
+            assert isinstance(flat_array, np.ndarray) and flat_array.ndim == 1
+            offsets_list = []
+            num_offsets = int(flat_array[0])
+            flat_offset = 1 + num_offsets
+            for offsets_length in flat_array[1:flat_offset]:
+                next_flat_offset = flat_offset + int(offsets_length)
+                offsets = flat_array[flat_offset:next_flat_offset].astype(np.int32)
+                offsets_list.append(offsets)
+                flat_offset = next_flat_offset
+
+            sub_arrays = flat_array[flat_offset:]
+            for offsets in reversed(offsets_list):
+                sub_arrays = [sub_arrays[i:j] for i, j in zip(offsets, offsets[1:])]
+            sub_arrays_list.append(sub_arrays)
+
+        return array_type(sub_arrays_list)
+
+    raise TypeError(f"Unflattening '{array_type}' not supported")

--- a/spatialpandas/io/__init__.py
+++ b/spatialpandas/io/__init__.py
@@ -2,5 +2,5 @@ from .parquet import (  # noqa
     read_parquet, read_parquet_dask, to_parquet, to_parquet_dask
 )
 from .tiledb import (  # noqa
-    read_tiledb, read_tiledb_cloud, to_tiledb, to_tiledb_cloud
+    read_tiledb, to_tiledb
 )

--- a/spatialpandas/io/__init__.py
+++ b/spatialpandas/io/__init__.py
@@ -1,3 +1,6 @@
 from .parquet import (  # noqa
     read_parquet, read_parquet_dask, to_parquet, to_parquet_dask
 )
+from .tiledb import (  # noqa
+    read_tiledb, to_tiledb
+)

--- a/spatialpandas/io/__init__.py
+++ b/spatialpandas/io/__init__.py
@@ -2,5 +2,5 @@ from .parquet import (  # noqa
     read_parquet, read_parquet_dask, to_parquet, to_parquet_dask
 )
 from .tiledb import (  # noqa
-    read_tiledb, to_tiledb
+    read_tiledb, to_tiledb, to_tiledb_cloud
 )

--- a/spatialpandas/io/__init__.py
+++ b/spatialpandas/io/__init__.py
@@ -2,5 +2,5 @@ from .parquet import (  # noqa
     read_parquet, read_parquet_dask, to_parquet, to_parquet_dask
 )
 from .tiledb import (  # noqa
-    read_tiledb, to_tiledb, to_tiledb_cloud
+    read_tiledb, read_tiledb_cloud, to_tiledb, to_tiledb_cloud
 )

--- a/spatialpandas/io/tiledb.py
+++ b/spatialpandas/io/tiledb.py
@@ -1,0 +1,38 @@
+from typing import Optional, Sequence
+
+import tiledb
+
+from ..geodataframe import GeoDataFrame
+from ..geometry import GeometryDtype
+from ..geometry.flattened import FlatGeometryArray, FlatGeometryDtype
+
+
+def to_tiledb(df: GeoDataFrame, uri: str, **kwargs) -> None:
+    new_columns = {}
+    varlen_types = set(kwargs.pop("varlen_types", ()))
+    for name, column in df.iteritems():
+        if isinstance(column.dtype, GeometryDtype):
+            new_column = FlatGeometryArray(column.values)
+            new_columns[name] = new_column
+            varlen_types.add(new_column.dtype)
+
+    if new_columns:
+        df = df.assign(**new_columns)
+
+    return tiledb.from_pandas(uri, df, varlen_types=varlen_types, **kwargs)
+
+
+def read_tiledb(
+    uri: str,
+    columns: Optional[Sequence[str]] = None,
+    ctx: Optional[tiledb.Ctx] = None,
+) -> GeoDataFrame:
+    df = tiledb.open_dataframe(uri, attrs=columns, use_arrow=False, ctx=ctx)
+    new_columns = {}
+    for name, column in df.iteritems():
+        if isinstance(column.dtype, FlatGeometryDtype):
+            new_columns[name] = column.astype(column.dtype.geometry_dtype)
+        else:
+            new_columns[name] = column
+
+    return GeoDataFrame(new_columns, index=df.index)

--- a/spatialpandas/io/tiledb.py
+++ b/spatialpandas/io/tiledb.py
@@ -1,5 +1,11 @@
-from typing import Optional, Sequence
+__all__ = ["to_tiledb", "read_tiledb", "to_tiledb_cloud"]
 
+import json
+from collections import defaultdict
+from typing import Iterable, Optional, Sequence
+
+import numpy as np
+import pandas as pd
 import tiledb
 
 from ..geodataframe import GeoDataFrame
@@ -7,19 +13,10 @@ from ..geometry import GeometryDtype
 from ..geometry.flattened import FlatGeometryArray, FlatGeometryDtype
 
 
-def to_tiledb(df: GeoDataFrame, uri: str, **kwargs) -> None:
-    new_columns = {}
-    varlen_types = set(kwargs.pop("varlen_types", ()))
-    for name, column in df.iteritems():
-        if isinstance(column.dtype, GeometryDtype):
-            new_column = FlatGeometryArray(column.values)
-            new_columns[name] = new_column
-            varlen_types.add(new_column.dtype)
-
-    if new_columns:
-        df = df.assign(**new_columns)
-
-    return tiledb.from_pandas(uri, df, varlen_types=varlen_types, **kwargs)
+def to_tiledb(df: GeoDataFrame, uri: str, ctx: Optional[tiledb.Ctx] = None) -> None:
+    df = _flatten_geometry_columns(df)
+    varlen_types = frozenset(_iter_flat_geometry_dtypes(df))
+    return tiledb.from_pandas(uri, df, varlen_types=varlen_types, ctx=ctx)
 
 
 def read_tiledb(
@@ -29,10 +26,146 @@ def read_tiledb(
 ) -> GeoDataFrame:
     df = tiledb.open_dataframe(uri, attrs=columns, use_arrow=False, ctx=ctx)
     new_columns = {}
-    for name, column in df.iteritems():
+    for name, column in df.items():
         if isinstance(column.dtype, FlatGeometryDtype):
             new_columns[name] = column.astype(column.dtype.geometry_dtype)
         else:
             new_columns[name] = column
 
     return GeoDataFrame(new_columns, index=df.index)
+
+
+def to_tiledb_cloud(
+    df: GeoDataFrame, uri: str, npartitions: int = 8, ctx: Optional[tiledb.Ctx] = None
+) -> None:
+    npartitions = min(len(df), npartitions)
+
+    # sort the dataframe by the first index level if not already sorted
+    # TODO: figure out how to take into account all levels for MultiIndex
+    sorted_index, indices = df.index.sortlevel(level=0)
+    if not sorted_index.equals(df.index):
+        df = df.iloc[indices]
+
+    # partition the dataframe into sub-dataframes based on the first index level
+    index_values = sorted_index.get_level_values(level=0).values
+    partition_slices = iter_partition_slices(index_values, npartitions)
+
+    # for each partition:
+    # - record its range
+    # - select the respective sub-dataframe
+    # - compute and record the bounds of each geometry column
+    partition_dfs = []
+    partition_ranges = []
+    all_bounds = defaultdict(list)
+    for partition_slice in partition_slices:
+        partition_df = df.loc[partition_slice]
+        partition_dfs.append(partition_df)
+        partition_ranges.append((partition_slice.start, partition_slice.stop))
+        for name, column in partition_df.items():
+            if isinstance(column.dtype, GeometryDtype):
+                all_bounds[name].append(column.total_bounds)
+
+    # stack the bounds of all partitions for each geometry column
+    partition_bounds = {
+        name: {"data": bounds_list, "columns": ("x0", "y0", "x1", "y1")}
+        for name, bounds_list in all_bounds.items()
+    }
+
+    # write all partitions to tiledb
+    _from_multiple_pandas(
+        uri,
+        dfs=map(_flatten_geometry_columns, partition_dfs),
+        # dense array if the df index is range(0, len(df))
+        sparse=not df.index.equals(pd.RangeIndex(len(df))),
+        varlen_types=frozenset(_iter_flat_geometry_dtypes(df)),
+        ctx=ctx,
+    )
+
+    # save the partition ranges and geometry bounds as metadata
+    with tiledb.open(uri, mode="w", ctx=ctx) as a:
+        a.meta["spatialpandas"] = json.dumps(
+            {
+                "partition_ranges": partition_ranges,
+                "partition_bounds": partition_bounds,
+            }
+        )
+
+
+def _iter_flat_geometry_dtypes(df: GeoDataFrame) -> Iterable[FlatGeometryDtype]:
+    for name, dtype in df.dtypes.items():
+        if isinstance(dtype, FlatGeometryDtype):
+            yield dtype
+        elif isinstance(dtype, GeometryDtype):
+            yield FlatGeometryDtype(dtype)
+
+
+def _flatten_geometry_columns(df: GeoDataFrame) -> GeoDataFrame:
+    new_columns = {
+        name: FlatGeometryArray(column.values)
+        for name, column in df.items()
+        if isinstance(column.dtype, GeometryDtype)
+    }
+    return df.assign(**new_columns) if new_columns else df
+
+
+def _from_multiple_pandas(uri: str, dfs: Iterable[pd.DataFrame], **kwargs) -> None:
+    # TODO: parallelize this loop
+    mode = "ingest"
+    for df in dfs:
+        # row_start_idx is used only for dense arrays, it's ignored for sparse
+        tiledb.from_pandas(
+            uri, df, mode=mode, full_domain=True, row_start_idx=df.index[0], **kwargs
+        )
+        mode = "append"
+
+
+def iter_partition_slices(array: np.ndarray, n: int) -> Iterable[slice]:
+    """Split `array` values into (at most) `n` partitions of approximately equal sum.
+
+    Each partition is represented as `slice(start, stop)` where *both `start` and `stop`
+    are inclusive*.
+
+    Note: the resulting partitioning is not guaranteed to be optimal.
+
+    :param array: The values to split
+    :param n: Max number of partitions
+    :return: An iterable of `array` value slices, one slice per partition
+    """
+    unique, counts = np.unique(array, return_counts=True)
+    # convert unique elements from numpy to pure python instances
+    unique = unique.tolist()
+
+    num_unique = len(unique)
+    if num_unique <= n:
+        # if equal or more partitions than unique elements, each partition
+        # consists of a single unique element
+        return (slice(item, item) for item in unique)
+
+    # Adapted from https://stackoverflow.com/a/54024280/240525
+    # finds the indices where the cumulative sums are sandwiched
+    p_size = len(array) / n
+    boundaries = np.searchsorted(
+        counts.cumsum(), np.arange(1, n) * p_size, side="right"
+    )
+
+    start_indices = np.r_[0, boundaries]
+    # if there are duplicates in start_indices, increment them
+    for i, start_index in enumerate(start_indices[:-1]):
+        if start_indices[i + 1] <= start_index:
+            start_indices[i + 1] = start_index + 1
+
+    # inclusive stop_indices: 1 less from the next start index
+    stop_indices = np.r_[start_indices[1:], num_unique]
+    stop_indices -= 1
+
+    # sanity checks
+    assert np.all(start_indices <= stop_indices)
+    for indices in start_indices, stop_indices:
+        assert np.all(indices >= 0)
+        assert np.all(indices < num_unique)
+        assert np.all(np.diff(indices) > 0)
+
+    return (
+        slice(unique[start], unique[stop])
+        for start, stop in zip(start_indices, stop_indices)
+    )

--- a/spatialpandas/io/tiledb.py
+++ b/spatialpandas/io/tiledb.py
@@ -3,6 +3,7 @@ __all__ = ["to_tiledb", "read_tiledb"]
 import itertools as it
 import json
 from collections import defaultdict
+from functools import partial
 from numbers import Real
 from typing import Any, Iterable, Mapping, Optional, Sequence, Tuple
 
@@ -23,7 +24,7 @@ from ..geometry.flattened import FlatGeometryArray, FlatGeometryDtype
 def to_tiledb(
     df: GeoDataFrame,
     uri: str,
-    npartitions: int = 0,
+    npartitions: int = 1,
     ctx: Optional[tiledb.Ctx] = None,
     tiledb_cloud_kwargs: Optional[Mapping[str, Any]] = None,
 ) -> None:
@@ -39,7 +40,7 @@ def to_tiledb(
     )
 
     npartitions = min(len(df), npartitions)
-    if npartitions <= 0:
+    if npartitions <= 1:
         return tiledb.from_pandas(
             uri, _flatten_geometry_columns(df), **from_pandas_kwargs
         )
@@ -100,8 +101,13 @@ def read_tiledb(
     geometry: Optional[str] = None,
     bounds: Optional[Tuple[Real, Real, Real, Real]] = None,
     ctx: Optional[tiledb.Ctx] = None,
+    tiledb_cloud_kwargs: Optional[Mapping[str, Any]] = None,
 ) -> GeoDataFrame:
-    kwargs = dict(geometry=geometry, attrs=columns, ctx=ctx)
+    kwargs = dict(
+        geometry=geometry,
+        open_df_kwargs=dict(attrs=columns, ctx=ctx),
+        tiledb_cloud_kwargs=tiledb_cloud_kwargs,
+    )
 
     # load the metadata for partitions and geometry column bounds
     partition_slices, partition_bounds = load_partition_metadata(uri)
@@ -143,26 +149,53 @@ def _read_geodataframe(
     uri: str,
     *partition_slices: slice,
     geometry: Optional[str] = None,
-    **kwargs,
+    open_df_kwargs: Optional[Mapping[str, Any]] = None,
+    tiledb_cloud_kwargs: Optional[Mapping[str, Any]] = None,
 ) -> GeoDataFrame:
-    # default to empty dataframe for no partition_slices
-    idxs = partition_slices or (None,)
-    column_lists = defaultdict(list)
-    for idx in idxs:
-        # read the dataframe for this partition slice
-        df = tiledb.open_dataframe(uri, idx=idx, use_arrow=False, **kwargs)
-        for name, column in df.items():
-            # unflatten the geometry columns
-            if isinstance(column.dtype, FlatGeometryDtype):
-                column = column.astype(column.dtype.geometry_dtype)
-            # collect columns across all partitions to concat them later
-            column_lists[name].append(column)
+    read_partition = partial(
+        _read_geodataframe_partition, uri=uri, **(open_df_kwargs or {})
+    )
 
-    new_columns = {
-        name: pd.concat(columns) if len(columns) > 1 else columns[0]
-        for name, columns in column_lists.items()
-    }
-    return GeoDataFrame(new_columns, geometry=geometry)
+    if len(partition_slices) <= 1:
+        idx = partition_slices[0] if partition_slices else None
+        named_columns = read_partition(idx=idx)
+
+    elif Delayed is None or tiledb_cloud_kwargs is None:
+        named_columns = _concat_columns(
+            read_partition(idx=idx) for idx in partition_slices
+        )
+
+    else:
+        read_tasks = [
+            Delayed(read_partition, **tiledb_cloud_kwargs)(idx=idx)
+            for idx in partition_slices
+        ]
+        named_columns = Delayed(_concat_columns, local=True)(read_tasks).compute()
+
+    return GeoDataFrame(named_columns, geometry=geometry)
+
+
+def _read_geodataframe_partition(
+    uri: str, idx: Optional[slice], **kwargs
+) -> Mapping[str, pd.Series]:
+    named_columns = {}
+    df = tiledb.open_dataframe(uri, idx=idx, use_arrow=False, **kwargs)
+    for name, column in df.items():
+        # unflatten the geometry columns
+        if isinstance(column.dtype, FlatGeometryDtype):
+            column = column.astype(column.dtype.geometry_dtype)
+        named_columns[name] = column
+    return named_columns
+
+
+def _concat_columns(
+    named_column_dicts: Iterable[Mapping[str, pd.Series]]
+) -> Mapping[str, pd.Series]:
+    concat_columns = defaultdict(list)
+    for named_columns in named_column_dicts:
+        for name, column in named_columns.items():
+            concat_columns[name].append(column)
+    return {name: pd.concat(columns) for name, columns in concat_columns.items()}
 
 
 def _flatten_geometry_columns(df: GeoDataFrame) -> GeoDataFrame:

--- a/spatialpandas/tests/geometry/strategies.py
+++ b/spatialpandas/tests/geometry/strategies.py
@@ -1,5 +1,4 @@
 import numpy as np
-from geopandas import GeoSeries
 from geopandas.array import from_shapely
 from hypothesis import HealthCheck, settings
 from hypothesis import strategies as st
@@ -29,7 +28,7 @@ st_points = arrays(
 
 
 @st.composite
-def st_point_array(draw, min_size=0, max_size=30, geoseries=False):
+def st_point_array(draw, min_size=0, max_size=30, astype=None):
     n = draw(st.integers(min_size, max_size))
     points = []
     for i in range(n):
@@ -41,13 +40,13 @@ def st_point_array(draw, min_size=0, max_size=30, geoseries=False):
         points.append(sg.Point(point))
 
     result = from_shapely(points)
-    if geoseries:
-        result = GeoSeries(result)
+    if astype:
+        result = astype(result)
     return result
 
 
 @st.composite
-def st_multipoint_array(draw, min_size=0, max_size=30, geoseries=False):
+def st_multipoint_array(draw, min_size=0, max_size=30, astype=None):
     n = draw(st.integers(min_size, max_size))
     lines = []
     for i in range(n):
@@ -60,13 +59,13 @@ def st_multipoint_array(draw, min_size=0, max_size=30, geoseries=False):
         lines.append(sg.MultiPoint(points))
 
     result = from_shapely(lines)
-    if geoseries:
-        result = GeoSeries(result)
+    if astype:
+        result = astype(result)
     return result
 
 
 @st.composite
-def st_line_array(draw, min_size=0, max_size=30, geoseries=False):
+def st_line_array(draw, min_size=0, max_size=30, astype=None):
     n = draw(st.integers(min_size, max_size))
     lines = []
     for i in range(n):
@@ -79,8 +78,8 @@ def st_line_array(draw, min_size=0, max_size=30, geoseries=False):
         lines.append(sg.LineString(points))
 
     result = from_shapely(lines)
-    if geoseries:
-        result = GeoSeries(result)
+    if astype:
+        result = astype(result)
     return result
 
 
@@ -100,7 +99,7 @@ def get_unique_points(
 
 
 @st.composite
-def st_ring_array(draw, min_size=3, max_size=30, geoseries=False):
+def st_ring_array(draw, min_size=3, max_size=30, astype=None):
     assert min_size >= 3
     n = draw(st.integers(min_size, max_size))
     rings = []
@@ -108,13 +107,13 @@ def st_ring_array(draw, min_size=3, max_size=30, geoseries=False):
         rings.append(sg.LinearRing(get_unique_points(n)))
 
     result = from_shapely(rings)
-    if geoseries:
-        result = GeoSeries(result)
+    if astype:
+        result = astype(result)
     return result
 
 
 @st.composite
-def st_multiline_array(draw, min_size=0, max_size=5, geoseries=False):
+def st_multiline_array(draw, min_size=0, max_size=5, astype=None):
     n = draw(st.integers(min_size, max_size))
     multilines = []
     for i in range(n):
@@ -131,8 +130,8 @@ def st_multiline_array(draw, min_size=0, max_size=5, geoseries=False):
         multilines.append(sg.MultiLineString(lines))
 
     result = from_shapely(multilines)
-    if geoseries:
-        result = GeoSeries(result)
+    if astype:
+        result = astype(result)
     return result
 
 
@@ -191,7 +190,7 @@ def st_polygon(draw, n=10, num_holes=None, xmid=0, ymid=0):
 
 
 @st.composite
-def st_polygon_array(draw, min_size=0, max_size=5, geoseries=False):
+def st_polygon_array(draw, min_size=0, max_size=5, astype=None):
     n = draw(st.integers(min_value=min_size, max_value=max_size))
     sg_polygons = [
         draw(st_polygon(xmid=draw(st.floats(-50, 50)), ymid=draw(st.floats(-50, 50))))
@@ -199,13 +198,13 @@ def st_polygon_array(draw, min_size=0, max_size=5, geoseries=False):
     ]
 
     result = from_shapely(sg_polygons)
-    if geoseries:
-        result = GeoSeries(result)
+    if astype:
+        result = astype(result)
     return result
 
 
 @st.composite
-def st_multipolygon_array(draw, min_size=0, max_size=5, geoseries=False):
+def st_multipolygon_array(draw, min_size=0, max_size=5, astype=None):
     n = draw(st.integers(min_value=min_size, max_value=max_size))
     sg_multipolygons = []
     for _ in range(n):
@@ -231,8 +230,8 @@ def st_multipolygon_array(draw, min_size=0, max_size=5, geoseries=False):
         sg_multipolygons.append(sg.MultiPolygon(polygons))
 
     result = from_shapely(sg_multipolygons)
-    if geoseries:
-        result = GeoSeries(result)
+    if astype:
+        result = astype(result)
     return result
 
 

--- a/spatialpandas/tests/geometry/test_cx.py
+++ b/spatialpandas/tests/geometry/test_cx.py
@@ -1,4 +1,5 @@
 import dask.dataframe as dd
+import geopandas as gp
 import pytest
 from hypothesis import given
 from pandas.testing import assert_frame_equal, assert_series_equal
@@ -29,7 +30,7 @@ def get_slices(v0, v1):
 
 
 @pytest.mark.slow
-@given(st_point_array(min_size=1, geoseries=True), st_bounds(orient=True))
+@given(st_point_array(min_size=1, astype=gp.GeoSeries), st_bounds(orient=True))
 @hyp_settings
 def test_point_cx_selection(gp_point, rect):
     x0, y0, x1, y1 = rect
@@ -41,7 +42,7 @@ def test_point_cx_selection(gp_point, rect):
 
 
 @pytest.mark.slow
-@given(st_multipoint_array(min_size=1, geoseries=True), st_bounds(orient=True))
+@given(st_multipoint_array(min_size=1, astype=gp.GeoSeries), st_bounds(orient=True))
 @hyp_settings
 def test_multipoint_cx_selection(gp_multipoint, rect):
     x0, y0, x1, y1 = rect
@@ -53,7 +54,7 @@ def test_multipoint_cx_selection(gp_multipoint, rect):
 
 
 @pytest.mark.slow
-@given(st_line_array(min_size=1, geoseries=True), st_bounds(orient=True))
+@given(st_line_array(min_size=1, astype=gp.GeoSeries), st_bounds(orient=True))
 @hyp_settings
 def test_line_cx_selection(gp_line, rect):
     x0, y0, x1, y1 = rect
@@ -65,7 +66,7 @@ def test_line_cx_selection(gp_line, rect):
 
 
 @pytest.mark.slow
-@given(st_multiline_array(min_size=1, geoseries=True), st_bounds(orient=True))
+@given(st_multiline_array(min_size=1, astype=gp.GeoSeries), st_bounds(orient=True))
 @hyp_settings
 def test_multiline_cx_selection(gp_multiline, rect):
     x0, y0, x1, y1 = rect
@@ -78,7 +79,7 @@ def test_multiline_cx_selection(gp_multiline, rect):
 
 @pytest.mark.slow
 @given(
-    st_polygon_array(min_size=1, geoseries=True),
+    st_polygon_array(min_size=1, astype=gp.GeoSeries),
     st_bounds(
         x_min=-150, x_max=150, y_min=-150, y_max=150, orient=True
     )
@@ -95,7 +96,7 @@ def test_polygon_cx_selection(gp_polygon, rect):
 
 @pytest.mark.slow
 @given(
-    st_multipolygon_array(min_size=1, geoseries=True),
+    st_multipolygon_array(min_size=1, astype=gp.GeoSeries),
     st_bounds(
         x_min=-150, x_max=150, y_min=-150, y_max=150, orient=True
     )
@@ -114,7 +115,7 @@ def test_multipolygon_cx_selection(gp_multipolygon, rect):
             assert all(expected == result)
 
 
-@given(st_multipoint_array(min_size=1, geoseries=True), st_bounds(orient=True))
+@given(st_multipoint_array(min_size=1, astype=gp.GeoSeries), st_bounds(orient=True))
 @hyp_settings
 def test_multipoint_cx_series_selection(gp_multipoint, rect):
     x0, y0, x1, y1 = rect
@@ -126,7 +127,7 @@ def test_multipoint_cx_series_selection(gp_multipoint, rect):
 
 
 @pytest.mark.slow
-@given(st_multipoint_array(min_size=6, geoseries=True), st_bounds(orient=True))
+@given(st_multipoint_array(min_size=6, astype=gp.GeoSeries), st_bounds(orient=True))
 @hyp_settings
 def test_multipoint_cx_series_selection_dask(gp_multipoint, rect):
     x0, y0, x1, y1 = rect
@@ -137,7 +138,7 @@ def test_multipoint_cx_series_selection_dask(gp_multipoint, rect):
     assert_series_equal(expected, result, obj='GeoSeries')
 
 
-@given(st_multipoint_array(min_size=1, geoseries=True), st_bounds(orient=True))
+@given(st_multipoint_array(min_size=1, astype=gp.GeoSeries), st_bounds(orient=True))
 @hyp_settings
 def test_multipoint_cx_frame_selection(gp_multipoint, rect):
     x0, y0, x1, y1 = rect
@@ -151,7 +152,7 @@ def test_multipoint_cx_frame_selection(gp_multipoint, rect):
 
 
 @pytest.mark.slow
-@given(st_multipoint_array(min_size=6, geoseries=True), st_bounds(orient=True))
+@given(st_multipoint_array(min_size=6, astype=gp.GeoSeries), st_bounds(orient=True))
 @hyp_settings
 def test_multipoint_cx_frame_selection_dask(gp_multipoint, rect):
     x0, y0, x1, y1 = rect

--- a/spatialpandas/tests/geometry/test_flattened.py
+++ b/spatialpandas/tests/geometry/test_flattened.py
@@ -1,0 +1,45 @@
+import numpy as np
+from hypothesis import given, settings, strategies
+
+from spatialpandas import GeoSeries
+from spatialpandas.geometry.flattened import (
+    flatten_geometry_array,
+    unflatten_geometry_array,
+)
+
+from .strategies import (
+    st_line_array,
+    st_multiline_array,
+    st_multipoint_array,
+    st_multipolygon_array,
+    st_point_array,
+    st_polygon_array,
+    st_ring_array,
+)
+
+
+@given(
+    gp_array=strategies.one_of(
+        st_point_array(min_size=1),
+        st_multipoint_array(min_size=1),
+        st_line_array(min_size=1),
+        st_ring_array(min_size=3),
+        st_multiline_array(min_size=1),
+        st_polygon_array(min_size=1),
+        st_multipolygon_array(min_size=1),
+    )
+)
+@settings(deadline=None, max_examples=100)
+def test_flatten_unflatten(gp_array):
+    sp_array = GeoSeries(gp_array).values
+
+    flattened = flatten_geometry_array(sp_array)
+    assert flattened.shape == sp_array.shape
+    for flat_array in flattened:
+        assert flat_array.ndim == 1
+        assert flat_array.dtype == sp_array.dtype.subtype
+
+    unflattened = unflatten_geometry_array(flattened, sp_array.dtype)
+    assert sp_array.__class__ is unflattened.__class__
+    assert sp_array.dtype == unflattened.dtype
+    np.testing.assert_array_equal(sp_array, unflattened)

--- a/spatialpandas/tests/geometry/test_to_geopandas.py
+++ b/spatialpandas/tests/geometry/test_to_geopandas.py
@@ -1,4 +1,5 @@
 import pytest
+import geopandas as gp
 from hypothesis import given
 from pandas.testing import assert_series_equal
 
@@ -15,35 +16,35 @@ from .strategies import (
 from spatialpandas import GeoSeries
 
 
-@given(st_point_array(geoseries=True))
+@given(st_point_array(astype=gp.GeoSeries))
 @hyp_settings
 def test_point_array_to_geopandas(gp_point):
     result = GeoSeries(gp_point, dtype='point').to_geopandas()
     assert_series_equal(result, gp_point)
 
 
-@given(st_multipoint_array(geoseries=True))
+@given(st_multipoint_array(astype=gp.GeoSeries))
 @hyp_settings
 def test_multipoint_array_to_geopandas(gp_multipoint):
     result = GeoSeries(gp_multipoint, dtype='multipoint').to_geopandas()
     assert_series_equal(result, gp_multipoint)
 
 
-@given(st_line_array(geoseries=True))
+@given(st_line_array(astype=gp.GeoSeries))
 @hyp_settings
 def test_line_array_to_geopandas(gp_line):
     result = GeoSeries(gp_line, dtype='line').to_geopandas()
     assert_series_equal(result, gp_line)
 
 
-@given(st_ring_array(geoseries=True))
+@given(st_ring_array(astype=gp.GeoSeries))
 @hyp_settings
 def test_ring_array_to_geopandas(gp_ring):
     result = GeoSeries(gp_ring, dtype='ring').to_geopandas()
     assert_series_equal(result, gp_ring)
 
 
-@given(st_multiline_array(geoseries=True))
+@given(st_multiline_array(astype=gp.GeoSeries))
 @hyp_settings
 def test_multiline_array_to_geopandas(gp_multiline):
     result = GeoSeries(gp_multiline, dtype='multiline').to_geopandas()
@@ -51,7 +52,7 @@ def test_multiline_array_to_geopandas(gp_multiline):
 
 
 @pytest.mark.slow
-@given(st_polygon_array(geoseries=True))
+@given(st_polygon_array(astype=gp.GeoSeries))
 @hyp_settings
 def test_polygon_array_to_geopandas(gp_polygon):
     result = GeoSeries(gp_polygon, dtype='polygon').to_geopandas()
@@ -59,7 +60,7 @@ def test_polygon_array_to_geopandas(gp_polygon):
 
 
 @pytest.mark.slow
-@given(st_multipolygon_array(geoseries=True))
+@given(st_multipolygon_array(astype=gp.GeoSeries))
 @hyp_settings
 def test_multipolygon_array_to_geopandas(gp_multipolygon):
     result = GeoSeries(gp_multipolygon, dtype='multipolygon').to_geopandas()

--- a/spatialpandas/tests/test_parquet.py
+++ b/spatialpandas/tests/test_parquet.py
@@ -26,9 +26,9 @@ hyp_settings = settings(
 
 
 @given(
-    gp_point=st_point_array(min_size=1, geoseries=True),
-    gp_multipoint=st_multipoint_array(min_size=1, geoseries=True),
-    gp_multiline=st_multiline_array(min_size=1, geoseries=True),
+    gp_point=st_point_array(min_size=1, astype=GeoSeries),
+    gp_multipoint=st_multipoint_array(min_size=1, astype=GeoSeries),
+    gp_multiline=st_multiline_array(min_size=1, astype=GeoSeries),
 )
 @hyp_settings
 def test_parquet(gp_point, gp_multipoint, gp_multiline, tmp_path_factory):
@@ -36,9 +36,9 @@ def test_parquet(gp_point, gp_multipoint, gp_multiline, tmp_path_factory):
         # Build dataframe
         n = min(len(gp_multipoint), len(gp_multiline))
         df = GeoDataFrame({
-            'point': GeoSeries(gp_point[:n]),
-            'multipoint': GeoSeries(gp_multipoint[:n]),
-            'multiline': GeoSeries(gp_multiline[:n]),
+            'point': gp_point[:n],
+            'multipoint': gp_multipoint[:n],
+            'multiline': gp_multiline[:n],
             'a': list(range(n))
         })
 
@@ -53,9 +53,9 @@ def test_parquet(gp_point, gp_multipoint, gp_multiline, tmp_path_factory):
 
 
 @given(
-    gp_point=st_point_array(min_size=1, geoseries=True),
-    gp_multipoint=st_multipoint_array(min_size=1, geoseries=True),
-    gp_multiline=st_multiline_array(min_size=1, geoseries=True),
+    gp_point=st_point_array(min_size=1, astype=GeoSeries),
+    gp_multipoint=st_multipoint_array(min_size=1, astype=GeoSeries),
+    gp_multiline=st_multiline_array(min_size=1, astype=GeoSeries),
 )
 @hyp_settings
 def test_parquet_columns(gp_point, gp_multipoint, gp_multiline,
@@ -64,9 +64,9 @@ def test_parquet_columns(gp_point, gp_multipoint, gp_multiline,
         # Build dataframe
         n = min(len(gp_multipoint), len(gp_multiline))
         df = GeoDataFrame({
-            'point': GeoSeries(gp_point[:n]),
-            'multipoint': GeoSeries(gp_multipoint[:n]),
-            'multiline': GeoSeries(gp_multiline[:n]),
+            'point': gp_point[:n],
+            'multipoint': gp_multipoint[:n],
+            'multiline': gp_multiline[:n],
             'a': list(range(n))
         })
 
@@ -79,8 +79,8 @@ def test_parquet_columns(gp_point, gp_multipoint, gp_multiline,
 
 
 @given(
-    gp_multipoint=st_multipoint_array(min_size=1, geoseries=True),
-    gp_multiline=st_multiline_array(min_size=1, geoseries=True),
+    gp_multipoint=st_multipoint_array(min_size=1, astype=GeoSeries),
+    gp_multiline=st_multiline_array(min_size=1, astype=GeoSeries),
 )
 @hyp_settings
 def test_parquet_dask(gp_multipoint, gp_multiline, tmp_path_factory):
@@ -88,8 +88,8 @@ def test_parquet_dask(gp_multipoint, gp_multiline, tmp_path_factory):
         # Build dataframe
         n = min(len(gp_multipoint), len(gp_multiline))
         df = GeoDataFrame({
-            'points': GeoSeries(gp_multipoint[:n]),
-            'lines': GeoSeries(gp_multiline[:n]),
+            'points': gp_multipoint[:n],
+            'lines': gp_multiline[:n],
             'a': list(range(n))
         })
         ddf = dd.from_pandas(df, npartitions=3)
@@ -129,16 +129,16 @@ def test_parquet_dask(gp_multipoint, gp_multiline, tmp_path_factory):
 
 
 @given(
-    gp_multipoint=st_multipoint_array(min_size=10, max_size=40, geoseries=True),
-    gp_multiline=st_multiline_array(min_size=10, max_size=40, geoseries=True),
+    gp_multipoint=st_multipoint_array(min_size=10, max_size=40, astype=GeoSeries),
+    gp_multiline=st_multiline_array(min_size=10, max_size=40, astype=GeoSeries),
 )
 @settings(deadline=None, max_examples=30)
 def test_pack_partitions(gp_multipoint, gp_multiline):
     # Build dataframe
     n = min(len(gp_multipoint), len(gp_multiline))
     df = GeoDataFrame({
-        'points': GeoSeries(gp_multipoint[:n]),
-        'lines': GeoSeries(gp_multiline[:n]),
+        'points': gp_multipoint[:n],
+        'lines': gp_multiline[:n],
         'a': list(range(n))
     }).set_geometry('lines')
     ddf = dd.from_pandas(df, npartitions=3)
@@ -165,8 +165,8 @@ def test_pack_partitions(gp_multipoint, gp_multiline):
 
 @pytest.mark.slow
 @given(
-    gp_multipoint=st_multipoint_array(min_size=60, max_size=100, geoseries=True),
-    gp_multiline=st_multiline_array(min_size=60, max_size=100, geoseries=True),
+    gp_multipoint=st_multipoint_array(min_size=60, max_size=100, astype=GeoSeries),
+    gp_multiline=st_multiline_array(min_size=60, max_size=100, astype=GeoSeries),
     use_temp_format=hs.booleans()
 )
 @settings(
@@ -187,8 +187,8 @@ def test_pack_partitions_to_parquet(gp_multipoint, gp_multiline,
         # Build dataframe
         n = min(len(gp_multipoint), len(gp_multiline))
         df = GeoDataFrame({
-            'points': GeoSeries(gp_multipoint[:n]),
-            'lines': GeoSeries(gp_multiline[:n]),
+            'points': gp_multipoint[:n],
+            'lines': gp_multiline[:n],
             'a': list(range(n))
         }).set_geometry('lines')
         ddf = dd.from_pandas(df, npartitions=3)
@@ -240,10 +240,10 @@ def test_pack_partitions_to_parquet(gp_multipoint, gp_multiline,
 
 @pytest.mark.slow
 @given(
-    gp_multipoint1=st_multipoint_array(min_size=10, max_size=40, geoseries=True),
-    gp_multiline1=st_multiline_array(min_size=10, max_size=40, geoseries=True),
-    gp_multipoint2=st_multipoint_array(min_size=10, max_size=40, geoseries=True),
-    gp_multiline2=st_multiline_array(min_size=10, max_size=40, geoseries=True),
+    gp_multipoint1=st_multipoint_array(min_size=10, max_size=40, astype=GeoSeries),
+    gp_multiline1=st_multiline_array(min_size=10, max_size=40, astype=GeoSeries),
+    gp_multipoint2=st_multipoint_array(min_size=10, max_size=40, astype=GeoSeries),
+    gp_multiline2=st_multiline_array(min_size=10, max_size=40, astype=GeoSeries),
 )
 @settings(deadline=None, max_examples=30, suppress_health_check=[HealthCheck.too_slow])
 def test_pack_partitions_to_parquet_glob(gp_multipoint1, gp_multiline1,
@@ -253,8 +253,8 @@ def test_pack_partitions_to_parquet_glob(gp_multipoint1, gp_multiline1,
         # Build dataframe1
         n = min(len(gp_multipoint1), len(gp_multiline1))
         df1 = GeoDataFrame({
-            'points': GeoSeries(gp_multipoint1[:n]),
-            'lines': GeoSeries(gp_multiline1[:n]),
+            'points': gp_multipoint1[:n],
+            'lines': gp_multiline1[:n],
             'a': list(range(n))
         }).set_geometry('lines')
         ddf1 = dd.from_pandas(df1, npartitions=3)
@@ -264,8 +264,8 @@ def test_pack_partitions_to_parquet_glob(gp_multipoint1, gp_multiline1,
         # Build dataframe2
         n = min(len(gp_multipoint2), len(gp_multiline2))
         df2 = GeoDataFrame({
-            'points': GeoSeries(gp_multipoint2[:n]),
-            'lines': GeoSeries(gp_multiline2[:n]),
+            'points': gp_multipoint2[:n],
+            'lines': gp_multiline2[:n],
             'a': list(range(n))
         }).set_geometry('lines')
         ddf2 = dd.from_pandas(df2, npartitions=3)
@@ -309,10 +309,10 @@ def test_pack_partitions_to_parquet_glob(gp_multipoint1, gp_multiline1,
 
 @pytest.mark.slow
 @given(
-    gp_multipoint1=st_multipoint_array(min_size=10, max_size=40, geoseries=True),
-    gp_multiline1=st_multiline_array(min_size=10, max_size=40, geoseries=True),
-    gp_multipoint2=st_multipoint_array(min_size=10, max_size=40, geoseries=True),
-    gp_multiline2=st_multiline_array(min_size=10, max_size=40, geoseries=True),
+    gp_multipoint1=st_multipoint_array(min_size=10, max_size=40, astype=GeoSeries),
+    gp_multiline1=st_multiline_array(min_size=10, max_size=40, astype=GeoSeries),
+    gp_multipoint2=st_multipoint_array(min_size=10, max_size=40, astype=GeoSeries),
+    gp_multiline2=st_multiline_array(min_size=10, max_size=40, astype=GeoSeries),
     bounds=st_bounds(),
 )
 @settings(deadline=None, max_examples=30, suppress_health_check=[HealthCheck.too_slow])
@@ -325,8 +325,8 @@ def test_pack_partitions_to_parquet_list_bounds(
         # Build dataframe1
         n = min(len(gp_multipoint1), len(gp_multiline1))
         df1 = GeoDataFrame({
-            'points': GeoSeries(gp_multipoint1[:n]),
-            'lines': GeoSeries(gp_multiline1[:n]),
+            'points': gp_multipoint1[:n],
+            'lines': gp_multiline1[:n],
             'a': list(range(n))
         }).set_geometry('lines')
         ddf1 = dd.from_pandas(df1, npartitions=3)
@@ -336,8 +336,8 @@ def test_pack_partitions_to_parquet_list_bounds(
         # Build dataframe2
         n = min(len(gp_multipoint2), len(gp_multiline2))
         df2 = GeoDataFrame({
-            'points': GeoSeries(gp_multipoint2[:n]),
-            'lines': GeoSeries(gp_multiline2[:n]),
+            'points': gp_multipoint2[:n],
+            'lines': gp_multiline2[:n],
             'a': list(range(n))
         }).set_geometry('lines')
         ddf2 = dd.from_pandas(df2, npartitions=3)

--- a/spatialpandas/tests/test_parquet.py
+++ b/spatialpandas/tests/test_parquet.py
@@ -6,15 +6,12 @@ import pandas as pd
 import pytest
 from hypothesis import HealthCheck, Phase, Verbosity, given, settings
 
-from .geometry.strategies import (
-    st_bounds,
-    st_multiline_array,
-    st_multipoint_array,
-    st_point_array,
-)
-from spatialpandas import GeoDataFrame, GeoSeries
+from spatialpandas import GeoDataFrame
 from spatialpandas.dask import DaskGeoDataFrame
 from spatialpandas.io import read_parquet, read_parquet_dask, to_parquet
+
+from .geometry.strategies import st_bounds, st_geodataframe
+
 
 dask.config.set(scheduler="single-threaded")
 
@@ -25,122 +22,59 @@ hyp_settings = settings(
 )
 
 
-@given(
-    gp_point=st_point_array(min_size=1, astype=GeoSeries),
-    gp_multipoint=st_multipoint_array(min_size=1, astype=GeoSeries),
-    gp_multiline=st_multiline_array(min_size=1, astype=GeoSeries),
-)
+@given(df=st_geodataframe())
 @hyp_settings
-def test_parquet(gp_point, gp_multipoint, gp_multiline, tmp_path_factory):
+def test_parquet(df, tmp_path_factory):
+    df.index.name = "range_idx"
     with tmp_path_factory.mktemp("spatialpandas", numbered=True) as tmp_path:
-        # Build dataframe
-        n = min(len(gp_multipoint), len(gp_multiline))
-        df = GeoDataFrame({
-            'point': gp_point[:n],
-            'multipoint': gp_multipoint[:n],
-            'multiline': gp_multiline[:n],
-            'a': list(range(n))
-        })
-
-        df.index.name = 'range_idx'
-
-        path = tmp_path / 'df.parq'
+        path = tmp_path / "df.parq"
         to_parquet(df, path)
-        df_read = read_parquet(str(path), columns=['point', 'multipoint', 'multiline', 'a'])
+
+        df_read = read_parquet(path)
         assert isinstance(df_read, GeoDataFrame)
         pd.testing.assert_frame_equal(df, df_read)
-        assert df_read.index.name == df.index.name
 
-
-@given(
-    gp_point=st_point_array(min_size=1, astype=GeoSeries),
-    gp_multipoint=st_multipoint_array(min_size=1, astype=GeoSeries),
-    gp_multiline=st_multiline_array(min_size=1, astype=GeoSeries),
-)
-@hyp_settings
-def test_parquet_columns(gp_point, gp_multipoint, gp_multiline,
-                         tmp_path_factory):
-    with tmp_path_factory.mktemp("spatialpandas", numbered=True) as tmp_path:
-        # Build dataframe
-        n = min(len(gp_multipoint), len(gp_multiline))
-        df = GeoDataFrame({
-            'point': gp_point[:n],
-            'multipoint': gp_multipoint[:n],
-            'multiline': gp_multiline[:n],
-            'a': list(range(n))
-        })
-
-        path = tmp_path / 'df.parq'
-        to_parquet(df, path)
-        columns = ['a', 'multiline']
+        columns = ["a", "multilines", "polygons"]
         df_read = read_parquet(str(path), columns=columns)
         assert isinstance(df_read, GeoDataFrame)
         pd.testing.assert_frame_equal(df[columns], df_read)
 
 
-@given(
-    gp_multipoint=st_multipoint_array(min_size=1, astype=GeoSeries),
-    gp_multiline=st_multiline_array(min_size=1, astype=GeoSeries),
-)
+@given(df=st_geodataframe(column_names=("points", "lines", "a")))
 @hyp_settings
-def test_parquet_dask(gp_multipoint, gp_multiline, tmp_path_factory):
+def test_parquet_dask(df, tmp_path_factory):
     with tmp_path_factory.mktemp("spatialpandas", numbered=True) as tmp_path:
-        # Build dataframe
-        n = min(len(gp_multipoint), len(gp_multiline))
-        df = GeoDataFrame({
-            'points': gp_multipoint[:n],
-            'lines': gp_multiline[:n],
-            'a': list(range(n))
-        })
         ddf = dd.from_pandas(df, npartitions=3)
 
-        path = tmp_path / 'ddf.parq'
+        path = tmp_path / "ddf.parq"
         ddf.to_parquet(str(path))
         ddf_read = read_parquet_dask(str(path))
 
-        # Check type
         assert isinstance(ddf_read, DaskGeoDataFrame)
+        assert ddf_read.geometry.name == "points"
 
         # Check that partition bounds were loaded
-        nonempty = np.nonzero(
-            np.asarray(ddf.map_partitions(len).compute() > 0)
-        )[0]
-        assert set(ddf_read._partition_bounds) == {'points', 'lines'}
-        expected_partition_bounds = (
-            ddf['points'].partition_bounds.iloc[nonempty].reset_index(drop=True)
-        )
-        expected_partition_bounds.index.name = 'partition'
-
-        pd.testing.assert_frame_equal(
-            expected_partition_bounds,
-            ddf_read._partition_bounds['points'],
-        )
-
-        expected_partition_bounds = (
-            ddf['lines'].partition_bounds.iloc[nonempty].reset_index(drop=True)
-        )
-        expected_partition_bounds.index.name = 'partition'
-        pd.testing.assert_frame_equal(
-            expected_partition_bounds,
-            ddf_read._partition_bounds['lines'],
-        )
-
-        assert ddf_read.geometry.name == 'points'
+        assert set(ddf_read._partition_bounds) == {"points", "lines"}
+        nonempty = np.nonzero(np.asarray(ddf.map_partitions(len).compute() > 0))[0]
+        for column in "points", "lines":
+            expected_partition_bounds = (
+                ddf[column].partition_bounds.iloc[nonempty].reset_index(drop=True)
+            )
+            expected_partition_bounds.index.name = "partition"
+            pd.testing.assert_frame_equal(
+                expected_partition_bounds,
+                ddf_read._partition_bounds[column],
+            )
 
 
 @given(
-    gp_multipoint=st_multipoint_array(min_size=10, max_size=40, astype=GeoSeries),
-    gp_multiline=st_multiline_array(min_size=10, max_size=40, astype=GeoSeries),
+    st_geodataframe(
+        min_size=10, max_size=40, column_names=("multipoints", "multilines", "a")
+    )
 )
 @settings(deadline=None, max_examples=30)
-def test_pack_partitions(gp_multipoint, gp_multiline):
-    # Build dataframe
-    n = min(len(gp_multipoint), len(gp_multiline))
-    df = GeoDataFrame({
-        'points': gp_multipoint[:n],
-        'lines': gp_multiline[:n],
-        'a': list(range(n))
-    }).set_geometry('lines')
+def test_pack_partitions(df):
+    df = df.set_geometry("multilines")
     ddf = dd.from_pandas(df, npartitions=3)
 
     # Pack partitions
@@ -150,14 +84,18 @@ def test_pack_partitions(gp_multipoint, gp_multiline):
     assert ddf_packed.npartitions == 4
 
     # Check that rows are now sorted in order of hilbert distance
-    total_bounds = df.lines.total_bounds
-    hilbert_distances = ddf_packed.lines.map_partitions(
-        lambda s: s.hilbert_distance(total_bounds=total_bounds)
-    ).compute().values
+    total_bounds = df.multilines.total_bounds
+    hilbert_distances = (
+        ddf_packed.multilines.map_partitions(
+            lambda s: s.hilbert_distance(total_bounds=total_bounds)
+        )
+        .compute()
+        .values
+    )
 
     # Compute expected total_bounds
     expected_distances = np.sort(
-        df.lines.hilbert_distance(total_bounds=total_bounds).values
+        df.multilines.hilbert_distance(total_bounds=total_bounds).values
     )
 
     np.testing.assert_equal(expected_distances, hilbert_distances)
@@ -165,45 +103,34 @@ def test_pack_partitions(gp_multipoint, gp_multiline):
 
 @pytest.mark.slow
 @given(
-    gp_multipoint=st_multipoint_array(min_size=60, max_size=100, astype=GeoSeries),
-    gp_multiline=st_multiline_array(min_size=60, max_size=100, astype=GeoSeries),
-    use_temp_format=hs.booleans()
+    df=st_geodataframe(
+        min_size=60, max_size=100, column_names=("multipoints", "multilines", "a")
+    ),
+    use_temp_format=hs.booleans(),
 )
 @settings(
     deadline=None,
     max_examples=30,
     suppress_health_check=[HealthCheck.too_slow],
-    phases=[
-        Phase.explicit,
-        Phase.reuse,
-        Phase.generate,
-        Phase.target
-    ],
+    phases=[Phase.explicit, Phase.reuse, Phase.generate, Phase.target],
     verbosity=Verbosity.verbose,
 )
-def test_pack_partitions_to_parquet(gp_multipoint, gp_multiline,
-                                    use_temp_format, tmp_path_factory):
+def test_pack_partitions_to_parquet(df, use_temp_format, tmp_path_factory):
     with tmp_path_factory.mktemp("spatialpandas", numbered=True) as tmp_path:
-        # Build dataframe
-        n = min(len(gp_multipoint), len(gp_multiline))
-        df = GeoDataFrame({
-            'points': gp_multipoint[:n],
-            'lines': gp_multiline[:n],
-            'a': list(range(n))
-        }).set_geometry('lines')
+        df = df.set_geometry("multilines")
         ddf = dd.from_pandas(df, npartitions=3)
 
-        path = tmp_path / 'ddf.parq'
+        path = tmp_path / "ddf.parq"
         if use_temp_format:
-            (tmp_path / 'scratch').mkdir(parents=True, exist_ok=True)
-            tempdir_format = str(tmp_path / 'scratch' / 'part-{uuid}-{partition:03d}')
+            (tmp_path / "scratch").mkdir(parents=True, exist_ok=True)
+            tempdir_format = str(tmp_path / "scratch" / "part-{uuid}-{partition:03d}")
         else:
             tempdir_format = None
 
         _retry_args = dict(
             wait_exponential_multiplier=10,
             wait_exponential_max=20000,
-            stop_max_attempt_number=4
+            stop_max_attempt_number=4,
         )
 
         ddf_packed = ddf.pack_partitions_to_parquet(
@@ -217,21 +144,25 @@ def test_pack_partitions_to_parquet(gp_multipoint, gp_multiline,
         assert ddf_packed.npartitions <= 12
 
         # Check that rows are now sorted in order of hilbert distance
-        total_bounds = df.lines.total_bounds
-        hilbert_distances = ddf_packed.lines.map_partitions(
-            lambda s: s.hilbert_distance(total_bounds=total_bounds)
-        ).compute().values
+        total_bounds = df.multilines.total_bounds
+        hilbert_distances = (
+            ddf_packed.multilines.map_partitions(
+                lambda s: s.hilbert_distance(total_bounds=total_bounds)
+            )
+            .compute()
+            .values
+        )
 
         # Compute expected total_bounds
         expected_distances = np.sort(
-            df.lines.hilbert_distance(total_bounds=total_bounds).values
+            df.multilines.hilbert_distance(total_bounds=total_bounds).values
         )
 
         np.testing.assert_equal(expected_distances, hilbert_distances)
-        assert ddf_packed.geometry.name == 'points'
+        assert ddf_packed.geometry.name == "multipoints"
 
         # Read columns
-        columns = ['a', 'lines']
+        columns = ["a", "multilines"]
         ddf_read_cols = read_parquet_dask(path, columns=columns)
         pd.testing.assert_frame_equal(
             ddf_read_cols.compute(), ddf_packed[columns].compute()
@@ -240,40 +171,28 @@ def test_pack_partitions_to_parquet(gp_multipoint, gp_multiline,
 
 @pytest.mark.slow
 @given(
-    gp_multipoint1=st_multipoint_array(min_size=10, max_size=40, astype=GeoSeries),
-    gp_multiline1=st_multiline_array(min_size=10, max_size=40, astype=GeoSeries),
-    gp_multipoint2=st_multipoint_array(min_size=10, max_size=40, astype=GeoSeries),
-    gp_multiline2=st_multiline_array(min_size=10, max_size=40, astype=GeoSeries),
+    df1=st_geodataframe(
+        min_size=10, max_size=40, column_names=("multipoints", "multilines", "a")
+    ),
+    df2=st_geodataframe(
+        min_size=10, max_size=40, column_names=("multipoints", "multilines", "a")
+    ),
 )
 @settings(deadline=None, max_examples=30, suppress_health_check=[HealthCheck.too_slow])
-def test_pack_partitions_to_parquet_glob(gp_multipoint1, gp_multiline1,
-                                         gp_multipoint2, gp_multiline2,
-                                         tmp_path_factory):
+def test_pack_partitions_to_parquet_glob(df1, df2, tmp_path_factory):
     with tmp_path_factory.mktemp("spatialpandas", numbered=True) as tmp_path:
-        # Build dataframe1
-        n = min(len(gp_multipoint1), len(gp_multiline1))
-        df1 = GeoDataFrame({
-            'points': gp_multipoint1[:n],
-            'lines': gp_multiline1[:n],
-            'a': list(range(n))
-        }).set_geometry('lines')
+        df1 = df1.set_geometry("multilines")
         ddf1 = dd.from_pandas(df1, npartitions=3)
-        path1 = tmp_path / 'ddf1.parq'
+        path1 = tmp_path / "ddf1.parq"
         ddf_packed1 = ddf1.pack_partitions_to_parquet(str(path1), npartitions=3)
 
-        # Build dataframe2
-        n = min(len(gp_multipoint2), len(gp_multiline2))
-        df2 = GeoDataFrame({
-            'points': gp_multipoint2[:n],
-            'lines': gp_multiline2[:n],
-            'a': list(range(n))
-        }).set_geometry('lines')
+        df2 = df2.set_geometry("multilines")
         ddf2 = dd.from_pandas(df2, npartitions=3)
-        path2 = tmp_path / 'ddf2.parq'
+        path2 = tmp_path / "ddf2.parq"
         ddf_packed2 = ddf2.pack_partitions_to_parquet(str(path2), npartitions=4)
 
         # Load both packed datasets with glob
-        ddf_globbed = read_parquet_dask(tmp_path / "ddf*.parq", geometry="lines")
+        ddf_globbed = read_parquet_dask(tmp_path / "ddf*.parq", geometry="multilines")
 
         # Check the number of partitions (< 7 can happen in the case of empty partitions)
         assert ddf_globbed.npartitions <= 7
@@ -285,69 +204,60 @@ def test_pack_partitions_to_parquet_glob(gp_multipoint1, gp_multiline1,
 
         # Check partition bounds
         expected_bounds = {
-            'points': pd.concat([
-                ddf_packed1._partition_bounds['points'],
-                ddf_packed2._partition_bounds['points'],
-            ]).reset_index(drop=True),
-            'lines': pd.concat([
-                ddf_packed1._partition_bounds['lines'],
-                ddf_packed2._partition_bounds['lines'],
-            ]).reset_index(drop=True),
+            "multipoints": pd.concat(
+                [
+                    ddf_packed1._partition_bounds["multipoints"],
+                    ddf_packed2._partition_bounds["multipoints"],
+                ]
+            ).reset_index(drop=True),
+            "multilines": pd.concat(
+                [
+                    ddf_packed1._partition_bounds["multilines"],
+                    ddf_packed2._partition_bounds["multilines"],
+                ]
+            ).reset_index(drop=True),
         }
-        expected_bounds['points'].index.name = 'partition'
-        expected_bounds['lines'].index.name = 'partition'
+        expected_bounds["multipoints"].index.name = "partition"
+        expected_bounds["multilines"].index.name = "partition"
         pd.testing.assert_frame_equal(
-            expected_bounds['points'], ddf_globbed._partition_bounds['points']
+            expected_bounds["multipoints"], ddf_globbed._partition_bounds["multipoints"]
         )
 
         pd.testing.assert_frame_equal(
-            expected_bounds['lines'], ddf_globbed._partition_bounds['lines']
+            expected_bounds["multilines"], ddf_globbed._partition_bounds["multilines"]
         )
 
-        assert ddf_globbed.geometry.name == 'lines'
+        assert ddf_globbed.geometry.name == "multilines"
 
 
 @pytest.mark.slow
 @given(
-    gp_multipoint1=st_multipoint_array(min_size=10, max_size=40, astype=GeoSeries),
-    gp_multiline1=st_multiline_array(min_size=10, max_size=40, astype=GeoSeries),
-    gp_multipoint2=st_multipoint_array(min_size=10, max_size=40, astype=GeoSeries),
-    gp_multiline2=st_multiline_array(min_size=10, max_size=40, astype=GeoSeries),
+    df1=st_geodataframe(
+        min_size=10, max_size=40, column_names=("multipoints", "multilines", "a")
+    ),
+    df2=st_geodataframe(
+        min_size=10, max_size=40, column_names=("multipoints", "multilines", "a")
+    ),
     bounds=st_bounds(),
 )
 @settings(deadline=None, max_examples=30, suppress_health_check=[HealthCheck.too_slow])
-def test_pack_partitions_to_parquet_list_bounds(
-        gp_multipoint1, gp_multiline1,
-        gp_multipoint2, gp_multiline2,
-        bounds, tmp_path_factory,
-):
+def test_pack_partitions_to_parquet_list_bounds(df1, df2, bounds, tmp_path_factory):
     with tmp_path_factory.mktemp("spatialpandas", numbered=True) as tmp_path:
-        # Build dataframe1
-        n = min(len(gp_multipoint1), len(gp_multiline1))
-        df1 = GeoDataFrame({
-            'points': gp_multipoint1[:n],
-            'lines': gp_multiline1[:n],
-            'a': list(range(n))
-        }).set_geometry('lines')
+        df1 = df1.set_geometry("multilines")
         ddf1 = dd.from_pandas(df1, npartitions=3)
-        path1 = tmp_path / 'ddf1.parq'
+        path1 = tmp_path / "ddf1.parq"
         ddf_packed1 = ddf1.pack_partitions_to_parquet(str(path1), npartitions=3)
 
-        # Build dataframe2
-        n = min(len(gp_multipoint2), len(gp_multiline2))
-        df2 = GeoDataFrame({
-            'points': gp_multipoint2[:n],
-            'lines': gp_multiline2[:n],
-            'a': list(range(n))
-        }).set_geometry('lines')
+        df2 = df2.set_geometry("multilines")
         ddf2 = dd.from_pandas(df2, npartitions=3)
-        path2 = tmp_path / 'ddf2.parq'
+        path2 = tmp_path / "ddf2.parq"
         ddf_packed2 = ddf2.pack_partitions_to_parquet(str(path2), npartitions=4)
 
         # Load both packed datasets with glob
         ddf_read = read_parquet_dask(
             [str(tmp_path / "ddf1.parq"), str(tmp_path / "ddf2.parq")],
-            geometry="points", bounds=bounds
+            geometry="multipoints",
+            bounds=bounds,
         )
 
         # Check the number of partitions (< 7 can happen in the case of empty partitions)
@@ -356,45 +266,55 @@ def test_pack_partitions_to_parquet_list_bounds(
         # Check contents
         xslice = slice(bounds[0], bounds[2])
         yslice = slice(bounds[1], bounds[3])
-        expected_df = pd.concat([
-            ddf_packed1.cx_partitions[xslice, yslice].compute(),
-            ddf_packed2.cx_partitions[xslice, yslice].compute()
-        ])
+        expected_df = pd.concat(
+            [
+                ddf_packed1.cx_partitions[xslice, yslice].compute(),
+                ddf_packed2.cx_partitions[xslice, yslice].compute(),
+            ]
+        )
         df_read = ddf_read.compute()
         pd.testing.assert_frame_equal(df_read, expected_df)
 
         # Compute expected partition bounds
-        points_bounds = pd.concat([
-            ddf_packed1._partition_bounds['points'],
-            ddf_packed2._partition_bounds['points'],
-        ]).reset_index(drop=True)
+        points_bounds = pd.concat(
+            [
+                ddf_packed1._partition_bounds["multipoints"],
+                ddf_packed2._partition_bounds["multipoints"],
+            ]
+        ).reset_index(drop=True)
 
         x0, y0, x1, y1 = bounds
         x0, x1 = (x0, x1) if x0 <= x1 else (x1, x0)
         y0, y1 = (y0, y1) if y0 <= y1 else (y1, y0)
         partition_inds = ~(
-            (points_bounds.x1 < x0) |
-            (points_bounds.y1 < y0) |
-            (points_bounds.x0 > x1) |
-            (points_bounds.y0 > y1)
+            (points_bounds.x1 < x0)
+            | (points_bounds.y1 < y0)
+            | (points_bounds.x0 > x1)
+            | (points_bounds.y0 > y1)
         )
         points_bounds = points_bounds[partition_inds].reset_index(drop=True)
 
-        lines_bounds = pd.concat([
-            ddf_packed1._partition_bounds['lines'],
-            ddf_packed2._partition_bounds['lines'],
-        ]).reset_index(drop=True)[partition_inds].reset_index(drop=True)
-        points_bounds.index.name = 'partition'
-        lines_bounds.index.name = 'partition'
+        lines_bounds = (
+            pd.concat(
+                [
+                    ddf_packed1._partition_bounds["multilines"],
+                    ddf_packed2._partition_bounds["multilines"],
+                ]
+            )
+            .reset_index(drop=True)[partition_inds]
+            .reset_index(drop=True)
+        )
+        points_bounds.index.name = "partition"
+        lines_bounds.index.name = "partition"
 
         # Check partition bounds
         pd.testing.assert_frame_equal(
-            points_bounds, ddf_read._partition_bounds['points']
+            points_bounds, ddf_read._partition_bounds["multipoints"]
         )
 
         pd.testing.assert_frame_equal(
-            lines_bounds, ddf_read._partition_bounds['lines']
+            lines_bounds, ddf_read._partition_bounds["multilines"]
         )
 
         # Check active geometry column
-        assert ddf_read.geometry.name == 'points'
+        assert ddf_read.geometry.name == "multipoints"

--- a/spatialpandas/tests/test_tiledb.py
+++ b/spatialpandas/tests/test_tiledb.py
@@ -7,6 +7,7 @@ from hypothesis import strategies as st
 from .geometry.strategies import st_bounds, st_geodataframe
 from spatialpandas import GeoDataFrame
 from spatialpandas.io.tiledb import (
+    Delayed,
     iter_partition_slices,
     load_partition_metadata,
     read_tiledb,
@@ -84,15 +85,22 @@ def test_load_partition_metadata(df, npartitions, tmp_path_factory):
     df=st_geodataframe(min_size=8, max_size=20),
     pack=st.booleans(),
     npartitions=st.sampled_from([0, 3]),
+    tiledb_cloud_kwargs=(
+        st.sampled_from([None, {"local": True}]) if Delayed is not None else st.none()
+    ),
 )
 @hyp_settings
-def test_to_tiledb_read_tiledb_roundtrip(df, pack, npartitions, tmp_path_factory):
+def test_to_tiledb_read_tiledb_roundtrip(
+    df, pack, npartitions, tiledb_cloud_kwargs, tmp_path_factory
+):
     if pack:
         pack_geodataframe(df, inplace=True)
 
     with tmp_path_factory.mktemp("spatialpandas", numbered=True) as tmp_path:
         uri = str(tmp_path / "df.tdb")
-        to_tiledb(df, uri, npartitions=npartitions)
+        to_tiledb(
+            df, uri, npartitions=npartitions, tiledb_cloud_kwargs=tiledb_cloud_kwargs
+        )
 
         geometry = "multilines"
 

--- a/spatialpandas/tests/test_tiledb.py
+++ b/spatialpandas/tests/test_tiledb.py
@@ -1,13 +1,10 @@
-import json
-
 import numpy as np
 import pandas as pd
 from hypothesis import HealthCheck, given, settings, strategies as st
 
-import tiledb
 from spatialpandas import GeoDataFrame
-from spatialpandas.io import read_tiledb, to_tiledb, to_tiledb_cloud
-from spatialpandas.io.tiledb import iter_partition_slices
+from spatialpandas.io import read_tiledb, read_tiledb_cloud, to_tiledb, to_tiledb_cloud
+from spatialpandas.io.tiledb import iter_partition_slices, load_partition_metadata
 
 from .geometry.strategies import st_geodataframe
 
@@ -99,16 +96,43 @@ def test_to_tiledb_cloud(df, pack, tmp_path_factory):
         # the dataframe rows are generally reordered
         pd.testing.assert_frame_equal(df[columns].sort_index(), df_read.sort_index())
 
-    with tiledb.open(uri) as a:
-        spatialpandas = json.loads(a.meta["spatialpandas"])
 
-        partition_ranges = spatialpandas["partition_ranges"]
+@given(df=st_geodataframe(min_size=8, max_size=20), pack=st.booleans())
+@hyp_settings
+def test_read_tiledb_cloud(df, pack, tmp_path_factory):
+    if pack:
+        pack_geodataframe(df, inplace=True)
+    with tmp_path_factory.mktemp("spatialpandas", numbered=True) as tmp_path:
+        uri = str(tmp_path / "df.tdb")
+        npartitions = 3
+        to_tiledb_cloud(df, uri, npartitions=npartitions)
+
+        df_read = read_tiledb_cloud(uri)
+        assert isinstance(df_read, GeoDataFrame)
+        # the dataframe rows are generally reordered
+        pd.testing.assert_frame_equal(df.sort_index(), df_read.sort_index())
+
+        columns = ["a", "multilines", "polygons"]
+        df_read = read_tiledb_cloud(uri, columns=columns)
+        assert isinstance(df_read, GeoDataFrame)
+        # the dataframe rows are generally reordered
+        pd.testing.assert_frame_equal(df[columns].sort_index(), df_read.sort_index())
+
+
+@given(df=st_geodataframe(min_size=3))
+@hyp_settings
+def test_load_partition_metadata(df, tmp_path_factory):
+    with tmp_path_factory.mktemp("spatialpandas", numbered=True) as tmp_path:
+        uri = str(tmp_path / "df.tdb")
+        npartitions = 3
+        to_tiledb_cloud(df, uri, npartitions=npartitions)
+
+        partition_ranges, partition_bounds = load_partition_metadata(uri)
+
         assert len(partition_ranges) == npartitions
-        assert all(len(r) == 2 for r in partition_ranges)
+        assert all(isinstance(r, slice) for r in partition_ranges)
 
-        partition_bounds = spatialpandas["partition_bounds"]
         assert set(partition_bounds.keys()).issubset(df.columns)
-        for df_dict in partition_bounds.values():
-            partition_bounds_df = pd.DataFrame(**df_dict)
+        for partition_bounds_df in partition_bounds.values():
             assert tuple(partition_bounds_df.columns) == ("x0", "y0", "x1", "y1")
             assert len(partition_bounds_df) == npartitions

--- a/spatialpandas/tests/test_tiledb.py
+++ b/spatialpandas/tests/test_tiledb.py
@@ -21,15 +21,6 @@ hyp_settings = settings(
 )
 
 
-def pack_geodataframe(df, *, geometry=None, p=15, inplace=False):
-    if geometry is None:
-        geometry = df.geometry
-    hilbert_distance = geometry.hilbert_distance(p=p)
-    df2 = df.set_index(hilbert_distance, inplace=inplace)
-    (df2 if df2 is not None else df).rename_axis("hilbert_distance", inplace=True)
-    return df2
-
-
 def test_iter_partition_slices():
     f = np.full  # f(frequency, value)
     a = np.r_[f(5, 1), f(3, 4), f(4, 6), f(2, 8), f(1, 10), f(2, 12), f(3, 15)]
@@ -94,7 +85,7 @@ def test_to_tiledb_read_tiledb_roundtrip(
     df, pack, npartitions, tiledb_cloud_kwargs, tmp_path_factory
 ):
     if pack:
-        pack_geodataframe(df, inplace=True)
+        df.pack(inplace=True)
 
     with tmp_path_factory.mktemp("spatialpandas", numbered=True) as tmp_path:
         uri = str(tmp_path / "df.tdb")
@@ -123,7 +114,7 @@ def test_to_tiledb_read_tiledb_roundtrip(
 )
 @hyp_settings
 def test_read_tiledb_bounds(df, geometry, bounds, tmp_path_factory):
-    pack_geodataframe(df, inplace=True)
+    df.pack(inplace=True)
 
     with tmp_path_factory.mktemp("spatialpandas", numbered=True) as tmp_path:
         uri = str(tmp_path / "df.tdb")

--- a/spatialpandas/tests/test_tiledb.py
+++ b/spatialpandas/tests/test_tiledb.py
@@ -120,26 +120,16 @@ def test_to_tiledb_read_tiledb_roundtrip(
     df=st_geodataframe(min_size=8, max_size=20),
     geometry=st.sampled_from([None, "lines", "polygons"]),
     bounds=st_bounds(),
-    tiledb_cloud_kwargs=(
-        st.sampled_from([None, {"local": True}]) if Delayed is not None else st.none()
-    ),
 )
 @hyp_settings
-def test_read_tiledb_bounds(
-    df, geometry, bounds, tiledb_cloud_kwargs, tmp_path_factory
-):
+def test_read_tiledb_bounds(df, geometry, bounds, tmp_path_factory):
     pack_geodataframe(df, inplace=True)
 
     with tmp_path_factory.mktemp("spatialpandas", numbered=True) as tmp_path:
         uri = str(tmp_path / "df.tdb")
         to_tiledb(df, uri, npartitions=3)
 
-        df_read = read_tiledb(
-            uri,
-            geometry=geometry,
-            bounds=bounds,
-            tiledb_cloud_kwargs=tiledb_cloud_kwargs,
-        )
+        df_read = read_tiledb(uri, geometry=geometry, bounds=bounds)
         assert isinstance(df_read, GeoDataFrame)
         assert df_read.geometry.name == geometry or df.geometry.name
 

--- a/spatialpandas/tests/test_tiledb.py
+++ b/spatialpandas/tests/test_tiledb.py
@@ -1,16 +1,63 @@
-import pandas as pd
-from hypothesis import HealthCheck, given, settings
+import json
 
+import numpy as np
+import pandas as pd
+from hypothesis import HealthCheck, given, settings, strategies as st
+
+import tiledb
 from spatialpandas import GeoDataFrame
-from spatialpandas.io import read_tiledb, to_tiledb
+from spatialpandas.io import read_tiledb, to_tiledb, to_tiledb_cloud
+from spatialpandas.io.tiledb import iter_partition_slices
 
 from .geometry.strategies import st_geodataframe
 
 hyp_settings = settings(
     deadline=None,
-    max_examples=100,
+    max_examples=20,
     suppress_health_check=[HealthCheck.too_slow],
 )
+
+
+def pack_geodataframe(df, *, geometry=None, p=15, inplace=False):
+    if geometry is None:
+        geometry = df.geometry
+    hilbert_distance = geometry.hilbert_distance(p=p)
+    df2 = df.set_index(hilbert_distance, inplace=inplace)
+    (df2 if df2 is not None else df).rename_axis("hilbert_distance", inplace=True)
+    return df2
+
+
+def test_iter_partition_slices():
+    f = np.full  # f(frequency, value)
+    a = np.r_[f(5, 1), f(3, 4), f(4, 6), f(2, 8), f(1, 10), f(2, 12), f(3, 15)]
+    np.random.shuffle(a)
+
+    assert list(iter_partition_slices(a, 1)) == [slice(1, 15)]
+    assert list(iter_partition_slices(a, 2)) == [slice(1, 4), slice(6, 15)]
+    assert list(iter_partition_slices(a, 3)) == [slice(1, 1), slice(4, 6), slice(8, 15)]
+    assert list(iter_partition_slices(a, 4)) == [
+        slice(1, 1),
+        slice(4, 4),
+        slice(6, 10),
+        slice(12, 15),
+    ]
+    assert list(iter_partition_slices(a, 5)) == [
+        slice(1, 1),
+        slice(4, 4),
+        slice(6, 6),
+        slice(8, 10),
+        slice(12, 15),
+    ]
+    assert list(iter_partition_slices(a, 6)) == [
+        slice(1, 1),
+        slice(4, 4),
+        slice(6, 6),
+        slice(8, 8),
+        slice(10, 10),
+        slice(12, 15),
+    ]
+    for p in range(7, len(a)):
+        assert list(iter_partition_slices(a, p)) == [slice(i, i) for i in np.unique(a)]
 
 
 @given(df=st_geodataframe())
@@ -29,3 +76,39 @@ def test_tiledb(df, tmp_path_factory):
         df_read = read_tiledb(uri, columns=columns)
         assert isinstance(df_read, GeoDataFrame)
         pd.testing.assert_frame_equal(df[columns], df_read)
+
+
+@given(df=st_geodataframe(min_size=8, max_size=20), pack=st.booleans())
+@hyp_settings
+def test_to_tiledb_cloud(df, pack, tmp_path_factory):
+    if pack:
+        pack_geodataframe(df, inplace=True)
+    with tmp_path_factory.mktemp("spatialpandas", numbered=True) as tmp_path:
+        uri = str(tmp_path / "df.tdb")
+        npartitions = 3
+        to_tiledb_cloud(df, uri, npartitions=npartitions)
+
+        df_read = read_tiledb(uri)
+        assert isinstance(df_read, GeoDataFrame)
+        # the dataframe rows are generally reordered
+        pd.testing.assert_frame_equal(df.sort_index(), df_read.sort_index())
+
+        columns = ["a", "multilines", "polygons"]
+        df_read = read_tiledb(uri, columns=columns)
+        assert isinstance(df_read, GeoDataFrame)
+        # the dataframe rows are generally reordered
+        pd.testing.assert_frame_equal(df[columns].sort_index(), df_read.sort_index())
+
+    with tiledb.open(uri) as a:
+        spatialpandas = json.loads(a.meta["spatialpandas"])
+
+        partition_ranges = spatialpandas["partition_ranges"]
+        assert len(partition_ranges) == npartitions
+        assert all(len(r) == 2 for r in partition_ranges)
+
+        partition_bounds = spatialpandas["partition_bounds"]
+        assert set(partition_bounds.keys()).issubset(df.columns)
+        for df_dict in partition_bounds.values():
+            partition_bounds_df = pd.DataFrame(**df_dict)
+            assert tuple(partition_bounds_df.columns) == ("x0", "y0", "x1", "y1")
+            assert len(partition_bounds_df) == npartitions

--- a/spatialpandas/tests/test_tiledb.py
+++ b/spatialpandas/tests/test_tiledb.py
@@ -84,7 +84,7 @@ def test_load_partition_metadata(df, npartitions, tmp_path_factory):
 @given(
     df=st_geodataframe(min_size=8, max_size=20),
     pack=st.booleans(),
-    npartitions=st.sampled_from([0, 3]),
+    npartitions=st.sampled_from([1, 3]),
     tiledb_cloud_kwargs=(
         st.sampled_from([None, {"local": True}]) if Delayed is not None else st.none()
     ),
@@ -120,16 +120,26 @@ def test_to_tiledb_read_tiledb_roundtrip(
     df=st_geodataframe(min_size=8, max_size=20),
     geometry=st.sampled_from([None, "lines", "polygons"]),
     bounds=st_bounds(),
+    tiledb_cloud_kwargs=(
+        st.sampled_from([None, {"local": True}]) if Delayed is not None else st.none()
+    ),
 )
 @hyp_settings
-def test_read_tiledb_bounds(df, geometry, bounds, tmp_path_factory):
+def test_read_tiledb_bounds(
+    df, geometry, bounds, tiledb_cloud_kwargs, tmp_path_factory
+):
     pack_geodataframe(df, inplace=True)
 
     with tmp_path_factory.mktemp("spatialpandas", numbered=True) as tmp_path:
         uri = str(tmp_path / "df.tdb")
         to_tiledb(df, uri, npartitions=3)
 
-        df_read = read_tiledb(uri, bounds=bounds, geometry=geometry)
+        df_read = read_tiledb(
+            uri,
+            geometry=geometry,
+            bounds=bounds,
+            tiledb_cloud_kwargs=tiledb_cloud_kwargs,
+        )
         assert isinstance(df_read, GeoDataFrame)
         assert df_read.geometry.name == geometry or df.geometry.name
 

--- a/spatialpandas/tests/test_tiledb.py
+++ b/spatialpandas/tests/test_tiledb.py
@@ -1,0 +1,31 @@
+import pandas as pd
+from hypothesis import HealthCheck, given, settings
+
+from spatialpandas import GeoDataFrame
+from spatialpandas.io import read_tiledb, to_tiledb
+
+from .geometry.strategies import st_geodataframe
+
+hyp_settings = settings(
+    deadline=None,
+    max_examples=100,
+    suppress_health_check=[HealthCheck.too_slow],
+)
+
+
+@given(df=st_geodataframe())
+@hyp_settings
+def test_tiledb(df, tmp_path_factory):
+    df.index.name = "range_idx"
+    with tmp_path_factory.mktemp("spatialpandas", numbered=True) as tmp_path:
+        uri = str(tmp_path / "df.tdb")
+        to_tiledb(df, uri)
+
+        df_read = read_tiledb(uri)
+        assert isinstance(df_read, GeoDataFrame)
+        pd.testing.assert_frame_equal(df, df_read)
+
+        columns = ["a", "multilines", "polygons"]
+        df_read = read_tiledb(uri, columns=columns)
+        assert isinstance(df_read, GeoDataFrame)
+        pd.testing.assert_frame_equal(df[columns], df_read)

--- a/spatialpandas/tests/test_tiledb.py
+++ b/spatialpandas/tests/test_tiledb.py
@@ -1,3 +1,5 @@
+import string
+
 import dask.dataframe as dd
 import numpy as np
 import pandas as pd
@@ -52,6 +54,81 @@ def test_iter_partition_slices():
     ]
     for p in range(7, len(a)):
         assert list(iter_partition_slices(a, p)) == [slice(i, i) for i in np.unique(a)]
+
+
+def test_iter_partition_slices_for_unique_values():
+    a = np.array(list(string.ascii_lowercase))
+
+    assert list(iter_partition_slices(a, 1)) == [slice("a", "z")]
+    assert list(iter_partition_slices(a, 2)) == [slice("a", "m"), slice("n", "z")]
+    assert list(iter_partition_slices(a, 3)) == [
+        slice("a", "h"),
+        slice("i", "q"),
+        slice("r", "z"),
+    ]
+    assert list(iter_partition_slices(a, 4)) == [
+        slice("a", "f"),
+        slice("g", "m"),
+        slice("n", "s"),
+        slice("t", "z"),
+    ]
+    assert list(iter_partition_slices(a, 5)) == [
+        slice("a", "e"),
+        slice("f", "j"),
+        slice("k", "o"),
+        slice("p", "t"),
+        slice("u", "z"),
+    ]
+    assert list(iter_partition_slices(a, 6)) == [
+        slice("a", "d"),
+        slice("e", "h"),
+        slice("i", "m"),
+        slice("n", "q"),
+        slice("r", "u"),
+        slice("v", "z"),
+    ]
+    assert list(iter_partition_slices(a, 7)) == [
+        slice("a", "c"),
+        slice("d", "g"),
+        slice("h", "k"),
+        slice("l", "n"),
+        slice("o", "r"),
+        slice("s", "v"),
+        slice("w", "z"),
+    ]
+    assert list(iter_partition_slices(a, 8)) == [
+        slice("a", "c"),
+        slice("d", "f"),
+        slice("g", "i"),
+        slice("j", "m"),
+        slice("n", "p"),
+        slice("q", "s"),
+        slice("t", "v"),
+        slice("w", "z"),
+    ]
+    assert list(iter_partition_slices(a, 9)) == [
+        slice("a", "b"),
+        slice("c", "e"),
+        slice("f", "h"),
+        slice("i", "k"),
+        slice("l", "n"),
+        slice("o", "q"),
+        slice("r", "t"),
+        slice("u", "w"),
+        slice("x", "z"),
+    ]
+    assert list(iter_partition_slices(a, 10)) == [
+        slice("a", "b"),
+        slice("c", "e"),
+        slice("f", "g"),
+        slice("h", "j"),
+        slice("k", "m"),
+        slice("n", "o"),
+        slice("p", "r"),
+        slice("s", "t"),
+        slice("u", "w"),
+        slice("x", "z"),
+    ]
 
 
 @given(df=st_geodataframe(min_size=8, max_size=20), npartitions=st.sampled_from([3, 7]))

--- a/spatialpandas/tests/tools/test_sjoin.py
+++ b/spatialpandas/tests/tools/test_sjoin.py
@@ -28,8 +28,8 @@ if not gpd_spatialindex:
 
 
 @given(
-    st_point_array(min_size=1, geoseries=True),
-    st_polygon_array(min_size=1, geoseries=True),
+    st_point_array(min_size=1),
+    st_polygon_array(min_size=1),
     hs.sampled_from(["inner", "left", "right"])
 )
 @hyp_settings


### PR DESCRIPTION
Add initial support for persisting GeoDataFrames to TileDB. The API is similar to the respective Parquet API:

- `spatialpandas.io.to_tiledb`: Writes a `spatialpandas.GeoDataFrame` to a TileDB array.
- `spatialpandas.io.read_tiledb`: Reads a TileDB array into a `spatialpandas.GeoDataFrame`.

`to_tiledb` can write a partitioned array, where each partition stores metadata for the boundaries of each geometry column. Then when `read_tiledb` is called with a `bounds` parameters, only the partitions that may overlap with the given rectangle specified by `bounds` are read.

Partitioning makes most sense if the initial `GeoDataFrame` is sorted spatially along a Hilbert space filling curve so that rows close in space end up in the same (or few) partitions. This reordering is provided by a new `GeoDataFrame.pack` method (similar to the existing `DaskGeoDataFrame.pack_partitions` for integration with Dask).

`to_tiledb` can optionally use [tiledb.cloud](https://docs.tiledb.com/cloud/client-api/task-graphs) (if installed) for writing the array concurrently per partition, using either the local (multithreaded) driver or TileDB Cloud UDFs.

The implementation employs a custom Pandas extension type (`FlatGeometryArray`) that flattens (nested) spatialpandas `GeometryArray`s on write an unflattens them on read.

Note: This PR requires a (still unmerged) [TileDB-Py PR](https://github.com/TileDB-Inc/TileDB-Py/pull/532) that adds support getting an empty dataframe.
